### PR TITLE
Display thumbnail image if any

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,9 @@
     %>
     <div id="<%= id %>" class="<%= classNames %>" data-id="<%= id %>">
       <div class="project-summary">
+        <% if (thumbnail) { %>
+        <img src="<%- thumbnail %>" class="thumbnail" width="100%" />
+        <% } %>
         <h2><%- title %></h2>
         <h3><%- creator %></h3>
         <p class="description"><%- description %></p>

--- a/js/project-card.js
+++ b/js/project-card.js
@@ -19,6 +19,7 @@ var ProjectCard = {
       title: projectData.Title ? projectData.Title : "",
       creator: projectData.Creator ? projectData.Creator : "",
       description: projectData.Description ? projectData.Description : "",
+      thumbnail: projectData['Thumbnail URL'] ? projectData['Thumbnail URL'] : "",
       interest: projectData.Interest ? projectData.Interest : "",
       link: projectData.URL ? projectData.URL : "",
       getInvolvedLink: projectData['Get involved URL'] ? projectData['Get involved URL'] : "",


### PR DESCRIPTION
Fixes #57 

To QA, search for "Mozfest"... you should see a Mozilla wordmark (I used it as the thumbnail) on the card. Don't worry about styling tweaks as those will be tackled in another ticket.

<img width="356" alt="screen shot 2016-08-02 at 3 14 24 pm" src="https://cloud.githubusercontent.com/assets/2896608/17347305/e6e6836e-58c3-11e6-8253-2a3362d28fb4.png">

/cc @cadecairos @acabunoc 