### PR TITLE
Added more metadata(`tags` `issues` `program` `type`)

### DIFF
--- a/css/projects.css
+++ b/css/projects.css
@@ -241,6 +241,9 @@ nav .container {
   border: 0;
 }
 
+.hidden-meta {
+  display: none;
+}
 
 /* search */
 

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
         featured ? "featured" : "",
       ].join(" ");
     %>
-    <div id="<%= id %>" class="<%= classNames %>" data-id="<%= id %>" data-timestamp="<%= rawTimestamp %>">
+    <div id="<%- id %>" class="<%- classNames %>" data-id="<%- id %>">
       <% if (thumbnail) { %>
       <img src="<%- thumbnail %>" class="thumbnail" width="100%" />
       <% } %>
@@ -100,6 +100,7 @@
         <h3><%- creator %> on <%- timestamp %></h3>
         <p class="description"><%- description %></p>
         <p class="interest"><%- interest %></p>
+        <div class="hidden-meta"><%- tags %> <%- issues %> <%- program %> <%- type %></div>
         <div class="project-links">
           <div class="btn-group">
             <% if (link) { %>

--- a/js/project-card.js
+++ b/js/project-card.js
@@ -1,16 +1,9 @@
 /* Project Card */
 
 var ProjectCard = {
-  ID_PREFIX: "p",
   template: _.template($("script#project-card-template").html()),
-  getProjectCardId: function(projectData) {
-    var timestamp = projectData.Timestamp ? projectData.Timestamp : false;
-    var projectId = timestamp ? Date.parse(timestamp) : '0';
-
-    return this.ID_PREFIX + projectId;
-  },
   buildHTML: function(projectData) {
-    var id = this.getProjectCardId(projectData);
+    var id = projectData.id;
     var timestamp = new Date(projectData.Timestamp);
     var month = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][timestamp.getMonth()];
     var dataForTemplate = {
@@ -24,6 +17,10 @@ var ProjectCard = {
       description: projectData.Description ? projectData.Description : "",
       thumbnail: projectData['Thumbnail URL'] ? projectData['Thumbnail URL'] : "",
       interest: projectData.Interest ? projectData.Interest : "",
+      tags: projectData.Tags,
+      issues: projectData.Issues,
+      program: projectData.Program,
+      type: projectData.Type,
       link: projectData.URL ? projectData.URL : "",
       getInvolvedLink: projectData['Get involved URL'] ? projectData['Get involved URL'] : "",
       detailViewLink: utility.getProjectDirectLink(id),
@@ -37,7 +34,7 @@ var ProjectCard = {
     $(event.target).parents(".project").find(".direct-link").css("visibility","visible").focus().select();
   },
   render: function(projectData) {
-    var id = ProjectCard.getProjectCardId(projectData);
+    var id = projectData.id;
     var isStarred = FavouritesManager.isProjectFavourited(id);
     var featured = projectData.Featured;
     var html = ProjectCard.buildHTML(projectData);

--- a/js/pulse.js
+++ b/js/pulse.js
@@ -124,8 +124,9 @@ var newProjectForm = {
 /* pulse maker */
 
 var PulseMaker = {
-  'url' : "https://spreadsheets.google.com/feeds/cells/"+GOOGLE_SHEET_ID+"/1/public/values?alt=json",
-  'projects' : [],
+  PROJECT_ID_PREFIX: "p",
+  url: "https://spreadsheets.google.com/feeds/cells/"+GOOGLE_SHEET_ID+"/1/public/values?alt=json",
+  projects: [],
   'init': function() {
     newProjectForm.init();
     FavouritesManager.init();
@@ -197,12 +198,18 @@ var PulseMaker = {
   'toggleAdditionalFeatures' : function () {
     if (FEATURE.orphans) { typography.preventTextOrphans(); }
   },
+  generatePulseProjectId(projectData) {
+    var timestamp = projectData.Timestamp ? projectData.Timestamp : false;
+    var projectId = timestamp ? Date.parse(timestamp) : '0';
+
+    return this.PROJECT_ID_PREFIX + projectId;
+  },
   'parseGoogleSheetData': function(driveData) {
     // Formats JSON data returned from Google Spreadsheet and formats it into
     // an array with a series of objects with key value pairs like "column-name":"value"
     var headings = {};
-    var newData = {};
-    var finalData = [];
+    var projects = {};
+    var parsedData = [];
     var entries = driveData.feed.entry;
 
     for(var i = 0; i < entries.length; i++){
@@ -216,18 +223,20 @@ var PulseMaker = {
       }
 
       if(row > 1) {
-        if(!newData[row]) {
-          newData[row] = {};
+        if(!projects[row]) {
+          projects[row] = {};
         }
-        newData[row][headings[col]] = value;
+        projects[row][headings[col]] = value;
       }
     }
 
-    for(var k in newData){
-      finalData.push(newData[k]);
+    for(var rowNum in projects){
+      var projectData = projects[rowNum];
+      projectData.id = this.generatePulseProjectId(projectData); 
+      parsedData.push(projectData);
     }
 
-    return finalData;
+    return parsedData;
   }
 };
 

--- a/js/views-manager.js
+++ b/js/views-manager.js
@@ -51,7 +51,7 @@ var ViewsManager = {
     if ( favedProjects.length > 0 ) {
       var sortedFavedProjects = [];
       this.projects.forEach(function(project) {
-        var index = FavouritesManager.getFavedProjects().indexOf( ProjectCard.getProjectCardId(project) );
+        var index = FavouritesManager.getFavedProjects().indexOf( project.id );
         if (index > -1) { 
           sortedFavedProjects[index] = project;
         }


### PR DESCRIPTION
Fixes #58 

Added more metadata(`tags` `issues` `program` `type`) to Project Card but do not make them visible on UI (see https://github.com/mozilla/network-pulse/issues/58#issuecomment-235935083)

Note that this PR is about making values of  `tags`, `issues`, `program`, and `type` searchable with the **current** search setup (i.e., search through `textContent` within Project Card)

/cc @acabunoc @cadecairos 

---

To test, you can temporary remove class `hidden-meta` from `index.html`. The additional metadata will then show on UI, within Project Card. Stay on the Features tab and search for "literacy", you should see 3 matching projects instead of 1 (<-- the result you will get if you try the same search term on https://mozilla.github.io/network-pulse/)