### PR TITLE
New detail view and flow

### DIFF
--- a/css/projects.css
+++ b/css/projects.css
@@ -63,14 +63,35 @@ nav .container {
   cursor: pointer;
 }
 
+.single-project-view .nav-item {
+  display: none;
+}
+
 .nav-item:not(:last-of-type) {
   margin-right: 15px;
 }
 
+#back-link,
 .nav-item.active,
 .nav-item:active,
 .nav-item:hover {
   color: #fff;
+}
+
+#back-link {
+  display: none;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+#back-link::before {
+  content: "<";
+  display: inline-block;
+  margin-right: 5px;
+}
+
+.single-project-view #back-link {
+  display: inline-block;
 }
 
 .btn,
@@ -198,6 +219,20 @@ nav .container {
   /* optimize swipe with class and transform. */
 }
 
+.project .interest,
+.project .network-connection-and-origin,
+.project .get-involved,
+.project .btn-group,
+.single-project-view .project .read-more-link {
+  display: none;
+}
+
+.single-project-view .project .interest,
+.single-project-view .project .network-connection-and-origin,
+.single-project-view .project .get-involved {
+  display: block;
+}
+
 .project-summary {
   padding: 15px;
 }
@@ -218,12 +253,13 @@ nav .container {
   margin: 0;
 }
 
-.project .btn-group {
+.single-project-view .project .btn-group {
   display: flex;
+  margin-top: 20px;
   margin-bottom: 20px;
 }
 
-.project .btn-group .btn:not(:last-child),
+.single-project-view .project .btn-group .btn:not(:last-child),
 .project .action-panel :not(:last-child) {
   margin-right: 10px;
 }
@@ -240,25 +276,23 @@ nav .container {
 
 .project .action-panel {
   display: flex;
+  flex-direction: row;
   align-items: center;
+  justify-content: space-between;
 }
 
 .project .action-panel img {
   margin-top: 5px;
 }
 
-.share-btn {
-  display: inline-block;
-  width: 23px;
-  height: 19px;
-  background: url(../svg/icon-link.svg) center center no-repeat;
-  background-size: auto 17px;
-  cursor: pointer;
+.single-project-view .project .action-panel {
+  flex-direction: row-reverse;
 }
 
-.share-btn:hover {
-  background: url(../svg/icon-link-selected.svg) center center no-repeat;
-  background-size: auto 17px;
+
+.read-more-link {
+  display: inline-block;
+  cursor: pointer;
 }
 
 .star {
@@ -275,20 +309,15 @@ nav .container {
   background-size: auto 16px;
 }
 
-.project-links input.direct-link {
-  visibility: hidden;
-  box-sizing: border-box;
-  color: #ADADAD;
-  width: 100%;
-  padding: 5px;
-  border: 0;
-}
-
 .hidden-meta {
   display: none;
 }
 
 /* search box */
+
+.single-project-view #search {
+  display: none;
+}
 
 #search { 
   background: #FFF;
@@ -422,6 +451,11 @@ footer {
     position: relative;
   }
 
+  .single-project-view #toggle-form-button {
+    bottom: none;
+    top: 50%;
+  }
+
   #toggle-form-button {
     position: absolute;
     bottom: 50%;
@@ -449,6 +483,10 @@ footer {
 
   .project {
     width: calc( (100% - 3*20px) / 3 );
+  }
+
+  .single-project-view .project {
+    width: calc( (100% - 2*20px) / 2 );
   }
 
   footer p {

--- a/index.html
+++ b/index.html
@@ -117,8 +117,10 @@
           Network Connection: <span class="network-connection"><%- networkConnection %></span> <span class="origin"><%- origin %></span>
         </p>
         <% } %>
+        <% if (getInvolvedText) { %>
         <p class="get-involved">
           <%- getInvolvedText %> <a href="<%- getInvolvedLink %>" target="_blank" class="get-involved-link">Get Involved</a>
+        <% } %>
         </p>
         <div class="project-links">
           <div class="btn-group">

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
 
   <nav>
     <div class="container">
+      <a id="back-link">Back</a>
       <a class="nav-item" id="featured-view-link">featured</a>
       <a class="nav-item" id="latest-view-link">latest</a>
       <a class="nav-item" id="favs-view-link">favs</a>
@@ -111,22 +112,26 @@
         <h3><%- creators %> on <%- timestamp %></h3>
         <p class="description"><%- description %></p>
         <p class="interest"><%- interest %></p>
-        <div class="hidden-meta"><%- tags %> <%- issues %> <%- program %> <%- type %></div>
+        <% if ( networkConnection || origin ) { %>
+        <p class="network-connection-and-origin">
+          Network Connection: <span class="network-connection"><%- networkConnection %></span> <span class="origin"><%- origin %></span>
+        </p>
+        <% } %>
+        <p class="get-involved">
+          <%- getInvolvedText %> <a href="<%- getInvolvedLink %>" target="_blank" class="get-involved-link">Get Involved</a>
+        </p>
         <div class="project-links">
           <div class="btn-group">
             <% if (link) { %>
             <a href="<%- link %>" target="_blank" class="btn visit-btn">Visit</a>
             <% } %>
-            <% if (getInvolvedLink) { %>
-            <a href="<%- getInvolvedLink %>" target="_blank" class="btn get-involved-btn">Get Involved</a>
-            <% } %>
           </div>
           <div class="action-panel">
-            <a class="share-btn"></a>
-            <input value="<%- detailViewLink %>" readonly="" class="direct-link" type="text">
+            <a href="<%- detailViewLink %>" class="read-more-link">Read more</a>
             <a class="star"></a>
           </div>
         </div>
+        <div class="hidden-meta"><%- tags %> <%- issues %> <%- program %> <%- type %></div>
       </div>
     </div>
   </script>

--- a/js/nav-items-manager.js
+++ b/js/nav-items-manager.js
@@ -1,4 +1,8 @@
 var NavItemsManager = {
+  backLinkHandler: function(event) {
+    event.preventDefault();
+    ViewsManager.returnFromSingleView();
+  },
   showFeaturedViewLinkHandler: function(event) {
     event.preventDefault();
     ViewsManager.showFeaturedView();
@@ -17,6 +21,7 @@ var NavItemsManager = {
   },
   init: function() {
     var self = this;
+    $("#back-link").on("click",self.backLinkHandler);
     $("#featured-view-link").on("click",self.showFeaturedViewLinkHandler);
     $("#latest-view-link").on("click",self.showLatestViewLinkHandler);
     $("#favs-view-link").on("click",self.showFavsViewLinkHandler);

--- a/js/project-card.js
+++ b/js/project-card.js
@@ -19,6 +19,8 @@ var ProjectCard = {
       description: projectData.Description ? projectData.Description : "",
       thumbnail: projectData['Thumbnail URL'] ? projectData['Thumbnail URL'] : "",
       interest: projectData.Interest ? projectData.Interest : "",
+      networkConnection: projectData['Network connection'] ? projectData['Network connection'] : "",
+      origin: projectData.Origin ? projectData.Origin : "",
       tags: projectData.Tags,
       issues: issues,
       belongsToOnlinePrivacyAndSecurityIssue: issuesAsArray.indexOf("Online Privacy & Security") > -1,
@@ -29,6 +31,7 @@ var ProjectCard = {
       program: projectData.Program,
       type: projectData.Type,
       link: projectData.URL ? projectData.URL : "",
+      getInvolvedText: projectData['Get involved'] ? projectData['Get involved'] : "",
       getInvolvedLink: projectData['Get involved URL'] ? projectData['Get involved URL'] : "",
       detailViewLink: utility.getProjectDirectLink(id),
       thumbnailView: false
@@ -36,18 +39,18 @@ var ProjectCard = {
 
     return this.template(dataForTemplate);
   },
-  shareBtnClickHandler: function(event) {
+  readMoreLinkClickHandler: function(event) {
     event.preventDefault();
-
     var $projectCard = $(this).parents(".project");
-    $projectCard.find(".direct-link").css("visibility","visible").focus().select();
-
+    var projectId = $projectCard.attr("id");
     ga('send', {
       hitType: 'event',
-      eventCategory: "Share Link Button",
+      eventCategory: "Read More Link",
       eventAction: 'click',
       eventLabel: $projectCard.data("title")
     });
+    utility.updateUrlWithoutReload("id",projectId);
+    ViewsManager.showSingleProjectView(projectId);
   },
   visitBtnClickHandler: function(event) {
     ga('send', {
@@ -79,9 +82,9 @@ var ProjectCard = {
       FavouritesManager.toggleProjectFavState(id,projectData.Title);
     });
 
-    $card.find(".share-btn").on("click", ProjectCard.shareBtnClickHandler);
+    $card.find(".read-more-link").on("click", ProjectCard.readMoreLinkClickHandler);
     $card.find(".visit-btn").on("click", ProjectCard.visitBtnClickHandler);
-    $card.find(".get-involved-btn").on("click", ProjectCard.getInvolvedBtnClickHandler);
+    $card.find(".get-involved-link").on("click", ProjectCard.getInvolvedBtnClickHandler);
 
     $("#project-container .projects").append($card);
   }

--- a/js/search.js
+++ b/js/search.js
@@ -2,6 +2,7 @@ var Search = {
   activated: false,
   inputBox: document.getElementById('search-box'),
   dismissButton: document.querySelector('#search .dismiss'),
+  currentSearchTerm: "",
   inputBoxKeyUpHandler: function(event) {
     var query = event.target.value;
     if (event.keyCode === 27) { // escape
@@ -27,8 +28,8 @@ var Search = {
   dismissButtonClickHandler: function(event) {
     Search.deactivate();
   },
-  activate: function(query) {
-    if ( !this.activated ) {
+  activate: function(query,cameFromSingleView) {
+    if ( !this.activated || (query&&cameFromSingleView) ) {
       this.activated = true;
       this.inputBox.parentElement.classList.add('activated');
       $("nav").slideUp(function(){
@@ -45,6 +46,7 @@ var Search = {
   },
   deactivate: function() {
     this.activated = false;
+    this.currentSearchTerm = "";
     this.inputBox.value = '';
     this.inputBox.blur();
     this.inputBox.parentElement.classList.remove('activated');
@@ -80,6 +82,7 @@ var Search = {
     } else {
       $(".project").hide();
     }
+    this.currentSearchTerm = query;
   },
   updateUrlQuery: function(query) {
     utility.updateUrlWithoutReload("keyword",query);

--- a/js/utility.js
+++ b/js/utility.js
@@ -21,7 +21,7 @@ var utility = {
     // all we want to do is to generate a direct link to a project
     // create an anchor element so that we can make use of the Location API
     var tempAnchor = document.createElement("a");
-    tempAnchor.href = "https://mzl.la/pulse";
+    tempAnchor.href = window.location.href.indexOf("mozilla.github.io/network-pulse") > -1 ? "https://mzl.la/pulse" : window.location.href;
     tempAnchor.search = "id="+projectId;
       
     return tempAnchor.href;

--- a/js/views-manager.js
+++ b/js/views-manager.js
@@ -41,11 +41,12 @@ var ViewsManager = {
   },
   returnToPrevious: function() {
     var viewsNames = this.VIEWS_NAMES;
+    console.log("returnToPrevious",this._currentViewMeta.viewName);
     switch(this._currentViewMeta.viewName) {
       case viewsNames.featured:
         this.showFeaturedView();
         break;
-      case viewsNames.lastest:
+      case viewsNames.latest:
         this.showLatestView();
         break;
       case viewsNames.favs:

--- a/js/views-manager.js
+++ b/js/views-manager.js
@@ -41,7 +41,6 @@ var ViewsManager = {
   },
   returnToPrevious: function() {
     var viewsNames = this.VIEWS_NAMES;
-    console.log("returnToPrevious",this._currentViewMeta.viewName);
     switch(this._currentViewMeta.viewName) {
       case viewsNames.featured:
         this.showFeaturedView();

--- a/js/views-manager.js
+++ b/js/views-manager.js
@@ -1,6 +1,5 @@
 var ViewsManager = {
   VIEWS_NAMES: {
-    single: "single-project-view",
     featured: "featured-view",
     latest: "latest-view",
     favs: "favs-view",
@@ -38,15 +37,11 @@ var ViewsManager = {
   },
   updateCurrentViewMeta: function(meta) {
     this._currentViewMeta.viewName = meta.viewName;
-    this._currentViewMeta.projectId = meta.projectId || "";
     this._currentViewMeta.issue = meta.issue || "";
   },
-  returnFromSearch: function() {
+  returnToPrevious: function() {
     var viewsNames = this.VIEWS_NAMES;
     switch(this._currentViewMeta.viewName) {
-      case viewsNames.single:
-        this.showSingleProjectView(this._currentViewMeta.projectId);
-        break;
       case viewsNames.featured:
         this.showFeaturedView();
         break;
@@ -60,7 +55,17 @@ var ViewsManager = {
         this.showIssuesView(this._currentViewMeta.issue);
         break;
       default:
-        this.showLatestView();
+        this.showFeaturedView();
+    }
+  },
+  returnFromSearch: function() {
+    this.returnToPrevious();
+  },
+  returnFromSingleView: function() {
+    if ( !Search.activated ) {
+      this.returnToPrevious();
+    } else {
+      Search.activate(Search.currentSearchTerm,true);
     }
   },
   renderProjectsIntoView: function(projects) {
@@ -86,14 +91,16 @@ var ViewsManager = {
     this.resetView();
     var $matchedProject = $("#"+projectId);
     if ( $matchedProject.length > 0 ) {
-      $matchedProject.addClass("single").show();
+      $("body").addClass("single-project-view");
+      $matchedProject.show();
     } else {
       this.MessageView.show("Something's wrong", "Check your URL or try a new search. Still no luck? <a href='https://github.com/mozilla/network-pulse/issues/new'>Let us know</a>.");
     }
-    this.updateCurrentViewMeta({
-      viewName: ViewsManager.VIEWS_NAMES.single,
-      projectId: projectId
-    });
+
+    // came to this view from search result
+    if (Search.activated) {
+      $("nav").show();
+    }
   },
   showFeaturedView: function() {
     this.resetView();
@@ -177,6 +184,7 @@ var ViewsManager = {
     this.$controlsContainer.hide();
     this.$issueBtns.removeClass("active");
     $(".nav-item").removeClass("active");
+    $("body").removeClass("single-project-view");
     if (options.clearAllProjectsFromDom === true) {
       this.$projectsContainer.children().remove();
     } else {
@@ -187,6 +195,8 @@ var ViewsManager = {
     if ( options.showAllProjects === true ) {
       this.$projectsContainer.children(".project").show();
     }
+
+    window.scrollTo(0,0);
   },
   init: function(allProjects) {
     this._projects = allProjects;


### PR DESCRIPTION
Fixes #175. 

/cc @cadecairos @acabunoc 

🔸 🔶 🔸 🔶 🔸 🔶 🔸 🔶 🔸 🔶 🔸 🔶 🔸 🔶 🔸 🔶 🔸 🔶 🔸 🔶 🔸 🔶 🔸 🔶 

## Review/QA instructions 

### 🔷 UI Changes (from https://github.com/mozilla/network-pulse/issues/175#issue-171541091)

#### Thumbnail card

- [ ] shortened intro (only the copy that appears on the form under "Description")
- [ ] the only buttons are 'Read more' which links to the detail view and Fav icon
- [ ] keep optional photo


#### Detail view

- [ ] "Back" button which links to thumbnail overview screen
- [ ] all copy available in the spreadsheet (in the following order: Description, Interest, Network connection, Origin, Get involved text followed by Get involved URL)
- [ ] note about Network Connection and Origin: Please add "Network Connection:" in front of the copy and then those two columns as a single paragraph
- [ ] "Visit" external link and Fav icon
- [ ] keep optional photo


### 🔷 Detail view

Three scenarios:

#### On Featured/Latest/Fav/Issues tab

- [ ] clicking on "read more" brings you to the detail view of a project.
- [ ] clicking on "back" brings you back to the tab you were on

#### Via share link

- [ ] detail view can be visited directly via share link, e.g., https://network-pulse.mofostaging.net/?id=p1469825978000 on staging and http://mozilla.github.io/network-pulse/?id=p1470198981000 on production
- [ ] clicking on "back" brings you to the Featured tab

#### On Search mode

- [ ] on Search mode, clicking on "read more" brings you to the detail view of a project.
- [ ] clikcingon "back" brings you back to the search result



🌴 🌷 🌴 🌷 🌴 🌷 🌴 🌷 🌴 🌷 🌴 🌷 🌴 🌷 🌴 🌷 🌴 🌷 🌴 🌷 🌴 🌷 