### PR TITLE
Load submitted project on tab switch

### DIFF
--- a/css/projects.css
+++ b/css/projects.css
@@ -479,17 +479,6 @@ label, input[type='radio'] {
   cursor:pointer;
 }
 
-/* loading */
-
-#loading {  
-  width:100%;
-  height:200px; 
-  line-height:200px;
-  text-align: center;
-  font-size:4em;
-  color:rgba(0,0,0,0.67);
-}
-
 /* site footer */
 
 footer {

--- a/index.html
+++ b/index.html
@@ -69,12 +69,6 @@
     </div>
   </div>
 
-  <div id="loading">
-    <div class="container">
-      loading...
-    </div>
-  </div>
-
   <footer>
     <div class="container">
       <p>Get new projects by email. <a id="sign-up-btn" href="https://groups.google.com/a/mozillafoundation.org/d/forum/pulse-notifications/join">Sign up</a>.</p>

--- a/js/views-manager.js
+++ b/js/views-manager.js
@@ -176,6 +176,8 @@ var ViewsManager = {
     utility.updateUrlWithoutReload();
   },
   resetView: function(resetOptions) {
+    this.updateProjectData();
+
     var options = {
       clearAllProjectsFromDom: resetOptions ? resetOptions.clearAllProjectsFromDom : false,
       showAllProjects: resetOptions ? resetOptions.showAllProjects : false
@@ -197,6 +199,14 @@ var ViewsManager = {
     }
 
     window.scrollTo(0,0);
+  },
+  updateProjectData: function() {
+    var updatedProjects = PulseMaker.getProjectsUpdated();
+    if (updatedProjects) {
+      this._projects = updatedProjects;
+      PulseMaker.setProjectsUpdated(false);
+    }
+    // else, do nothing
   },
   init: function(allProjects) {
     this._projects = allProjects;

--- a/js/views-manager.js
+++ b/js/views-manager.js
@@ -202,11 +202,11 @@ var ViewsManager = {
   },
   updateProjectData: function() {
     var updatedProjects = PulseMaker.getProjectsUpdated();
-    if (updatedProjects) {
-      this._projects = updatedProjects;
-      PulseMaker.setProjectsUpdated(false);
+    if (!updatedProjects) {
+      return;
     }
-    // else, do nothing
+    this._projects = updatedProjects;
+    PulseMaker.setProjectsUpdated(false);
   },
   init: function(allProjects) {
     this._projects = allProjects;


### PR DESCRIPTION
Fixes #111

@cadecairos @acabunoc ✨ 

I removed a bunch of legacy code in this PR and I left inline comments for them.

Other than that, major things I did in this PR

- removed `PulseMaker.renderApp` method and moved relevant code to `PulseMaker.init` instead
- added callback to `PulseMaker.getData`
- added `PulseMaker._projectsUpdated` property
- closing "add new" form triggers data fetching
- on **tab switch**, check to see if there's updated project data available. Load updated data if exists.

To test,

1. try adding a new project
2. close form
3. navigate to the Latest Tab and see if your project appears