### PR TITLE
add default port to server script

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,8 @@ const app = express();
 
 import env from "./config/env.generated.json";
 
-const PORT = env.PORT || process.env.PORT;
+const defaultPort = 3000;
+const PORT = env.PORT || process.env.PORT || defaultPort;
 
 app.use(express.static(path.resolve(__dirname, `dist`)));
 


### PR DESCRIPTION
our heroku emergency fix forgot to ensure that there is a default port in case neither the env.generates.json nor the process environment contain PORT values.