### PR TITLE
Added missing trailing slash to a API route

### DIFF
--- a/js/service.js
+++ b/js/service.js
@@ -176,7 +176,7 @@ export default {
   },
   entry: {
     get: function(entryId) {
-      return getDataFromURL(`${pulseAPI}/entries/${entryId}`);
+      return getDataFromURL(`${pulseAPI}/entries/${entryId}/`);
     }
   },
   logout: function() {


### PR DESCRIPTION
Fixes #437

Added missing trailing slash to the `/entries/entryID/` API route