### PR TITLE
quote fixes for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "watch:html": "chokidar 'index.html' -c 'npm run build-client:static'",
     "watch:js": "chokidar 'main.jsx' 'routes.jsx' 'js/**/*.js' 'components/**/*.jsx' 'pages/**/*.jsx' 'pages/**/*.js' 'webpack.config.js' -c 'npm run build-client:js'",
     "test": "run-s test:**",
-    "test:js": "eslint --config .eslintrc.yaml 'main.jsx' 'js/**/*.js' 'components/**/*.jsx' 'pages/**/*.jsx' webpack.config.js",
-    "test:scss": "stylelint --config .stylelintrc 'components/**/*.scss' 'pages/**/*.scss' 'scss/**/*.scss' --syntax scss",
+    "test:js": "eslint --config .eslintrc.yaml main.jsx \"js/**/*.js\" \"components/**/*.jsx\" \"pages/**/*.jsx\" webpack.config.js",
+    "test:scss": "stylelint --config .stylelintrc \"components/**/*.scss\" \"pages/**/*.scss\" \"scss/**/*.scss\" --syntax scss",
     "postinstall": "npm run build"
   },
   "babel": {


### PR DESCRIPTION
Windows passes single quotes as "part of the argument", so needs double quotes for these tasks to run properly