### PR TITLE
Migrating away from React.PropType

### DIFF
--- a/components/footer/footer.jsx
+++ b/components/footer/footer.jsx
@@ -44,4 +44,4 @@ const Footer = () => {
   );
 };
 
-export { Footer as default };
+export default Footer;

--- a/components/hint-message/hint-message.jsx
+++ b/components/hint-message/hint-message.jsx
@@ -27,4 +27,4 @@ HintMessage.propTypes = {
   linkComponent: PropTypes.element.isRequired
 };
 
-export { HintMessage as default };
+export default HintMessage;

--- a/components/project-card/project-card.jsx
+++ b/components/project-card/project-card.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import ReactGA from 'react-ga';
 import { Link } from 'react-router';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import moment from 'moment';
 import { getBookmarks, saveBookmarks } from '../../js/bookmarks-manager';
 
-const Details = React.createClass({
-  propTypes: {
-    createGaEventConfig: React.PropTypes.func.isRequired
-  },
+class Details extends React.Component {
   handleVisitBtnClick() {
     ReactGA.event(this.props.createGaEventConfig(`Visit button`, `Clicked`, `beacon`));
-  },
+  }
+
   handleGetInvolvedLinkClick() {
     ReactGA.event(this.props.createGaEventConfig(`Get involved`, `Clicked`, `beacon`));
-  },
+  }
+
   render() {
     let props = this.props;
     let getInvolvedText = props.getInvolved ? props.getInvolved : null;
@@ -27,34 +27,19 @@ const Details = React.createClass({
               { props.contentUrl ? <a href={props.contentUrl} target="_blank" className="btn btn-block btn-outline-info btn-view" onClick={this.handleVisitBtnClick}>Visit</a> : null }
             </div>) : null;
   }
-});
+}
+Details.propTypes = {
+  createGaEventConfig: PropTypes.func.isRequired
+};
 
-export default React.createClass({
-  getInitialState() {
-    return {
+class ProjectCard extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       bookmarked: false
     };
-  },
-  getDefaultProps() {
-    return {
-      onDetailView: false
-    };
-  },
-  propTypes: {
-    id: React.PropTypes.number.isRequired,
-    creators: React.PropTypes.array,
-    description: React.PropTypes.string.isRequired,
-    featured: React.PropTypes.bool,
-    getInvolved: React.PropTypes.string,
-    getInvolvedUrl: React.PropTypes.string,
-    interest: React.PropTypes.string,
-    issues: React.PropTypes.arrayOf(React.PropTypes.string),
-    thumbnail: React.PropTypes.string,
-    created: React.PropTypes.string,
-    title: React.PropTypes.string.isRequired,
-    contentUrl: React.PropTypes.string,
-    onDetailView: React.PropTypes.bool
-  },
+  }
+
   createGaEventConfig(category = ``, action = ``, transport = ``) {
     let config = {
       category: `Entry Card - ${category}`,
@@ -67,7 +52,8 @@ export default React.createClass({
     }
 
     return config;
-  },
+  }
+
   componentDidMount() {
     if (this.urlToShare) {
       // TODO:FIXME: not sure if this is the best way to display URL of the current page
@@ -76,7 +62,8 @@ export default React.createClass({
 
     this.setInitialBookmarkedStatus();
 
-  },
+  }
+
   setInitialBookmarkedStatus() {
     let bookmarks = getBookmarks();
     let bookmarked;
@@ -91,17 +78,20 @@ export default React.createClass({
       }
       this.setState({bookmarked: bookmarked});
     }
-  },
+  }
+
   bookmarkProject(bookmarks) {
     ReactGA.event(this.createGaEventConfig(`Bookmark button`, `Bookmarked`));
     bookmarks.unshift(this.props.id);
     this.setState({bookmarked: true});
-  },
+  }
+
   unbookmarkProject(bookmarks,index) {
     ReactGA.event(this.createGaEventConfig(`Bookmark button`, `Unbookmarked`));
     bookmarks.splice(index,1);
     this.setState({bookmarked: false});
-  },
+  }
+
   toggleBookmarkedState() {
     if (document && document.onanimationend !== `undefined`) {
       this.refs.heart.classList.add(`beating`);
@@ -122,29 +112,35 @@ export default React.createClass({
       }
       saveBookmarks(bookmarks);
     }
-  },
+  }
+
   handleThumbnailClick() {
     ReactGA.event(this.createGaEventConfig(`Thumbnail`, `Clicked`));
-  },
+  }
+
   handleTitleClick() {
     ReactGA.event(this.createGaEventConfig(`Title`, `Clicked`));
-  },
+  }
+
   handleReadMoreClick() {
     ReactGA.event(this.createGaEventConfig(`Read more`, `Clicked`));
-  },
+  }
+
   handleShareBtnClick() {
     ReactGA.event(this.createGaEventConfig(`Reveal entry share link`, `Clicked`));
     this.shareBtn.classList.add(`active`);
     this.urlToShare.focus();
     this.urlToShare.select();
-  },
+  }
+
   renderTitle(detailViewLink) {
     let title = this.props.title;
     if (!this.props.onDetailView) {
       title = <Link to={detailViewLink} onClick={this.handleTitleClick}>{title}</Link>;
     }
     return <h2>{title}</h2>;
-  },
+  }
+
   renderThumbnail(detailViewLink) {
     let thumbnailSource = this.props.thumbnail;
 
@@ -155,7 +151,8 @@ export default React.createClass({
                 <img src={thumbnailSource} />
               </div>
             </Link>;
-  },
+  }
+
   renderActionPanel(detailViewLink) {
     let actionPanel = this.props.onDetailView ?
                   (<div className="share">
@@ -169,20 +166,23 @@ export default React.createClass({
             {actionPanel}
             <a className="heart" ref="heart" onClick={this.toggleBookmarkedState}></a>
           </div>;
-  },
+  }
+
   renderCreatorInfo() {
     if (this.props.creators.length === 0) return null;
 
     return <small className="creator d-block text-muted">
              By {this.props.creators.join(`, `)}
           </small>;
-  },
+  }
+
   renderTimePosted() {
     if (!this.props.created) return null;
     return <small className="time-posted d-block text-muted">
             Added {moment(this.props.created).format(`MMM DD, YYYY`)}
           </small>;
-  },
+  }
+
   render() {
     let classnames = classNames({
       "project-card": true,
@@ -212,4 +212,24 @@ export default React.createClass({
       </div>
     );
   }
-});
+}
+ProjectCard.propTypes = {
+  id: PropTypes.number.isRequired,
+  creators: PropTypes.array,
+  description: PropTypes.string.isRequired,
+  featured: PropTypes.bool,
+  getInvolved: PropTypes.string,
+  getInvolvedUrl: PropTypes.string,
+  interest: PropTypes.string,
+  issues: PropTypes.arrayOf(React.PropTypes.string),
+  thumbnail: PropTypes.string,
+  created: PropTypes.string,
+  title: PropTypes.string.isRequired,
+  contentUrl: PropTypes.string,
+  onDetailView: PropTypes.bool
+};
+ProjectCard.defaultProps = {
+  onDetailView: false
+};
+
+export { ProjectCard as default };

--- a/components/project-card/project-card.jsx
+++ b/components/project-card/project-card.jsx
@@ -221,7 +221,7 @@ ProjectCard.propTypes = {
   getInvolved: PropTypes.string,
   getInvolvedUrl: PropTypes.string,
   interest: PropTypes.string,
-  issues: PropTypes.arrayOf(React.PropTypes.string),
+  issues: PropTypes.arrayOf(PropTypes.string),
   thumbnail: PropTypes.string,
   created: PropTypes.string,
   title: PropTypes.string.isRequired,
@@ -232,4 +232,4 @@ ProjectCard.defaultProps = {
   onDetailView: false
 };
 
-export { ProjectCard as default };
+export default ProjectCard;

--- a/components/project-list/project-list.jsx
+++ b/components/project-list/project-list.jsx
@@ -1,39 +1,34 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ProjectCard from '../project-card/project-card.jsx';
 import Utility from '../../js/utility.js';
 import pageSettings from '../../js/app-page-settings';
 
-export default React.createClass({
-  getInitialState() {
-    return {
+class ProjectList extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       inPageUpdate: false
     };
-  },
-  getDefaultProps() {
-    return {
-      entries: []
-    };
-  },
-  propTypes: {
-    entries: React.PropTypes.array.isRequired,
-    loadingData: React.PropTypes.bool.isRequired,
-    moreEntriesToFetch: React.PropTypes.bool.isRequired,
-    fetchData: React.PropTypes.func.isRequired
-  },
+  }
+
   componentDidUpdate() {
     if (!this.state.inPageUpdate && this.props.restoreScrollPosition) {
       pageSettings.restoreScrollPosition();
     }
-  },
+  }
+
   handleLoadMoreBtnClick() {
     this.props.fetchData();
     this.setState({inPageUpdate: true});
-  },
+  }
+
   renderProjectCards() {
     return this.props.entries.map(project => {
       return <ProjectCard key={project.id} {...Utility.processEntryData(project)} />;
     });
-  },
+  }
+
   renderLoadingNotice() {
     if (!this.props.loadingData ) return null;
 
@@ -43,14 +38,16 @@ export default React.createClass({
               <div></div>
               <div></div>
             </div>;
-  },
+  }
+
   renderViewMoreBtn() {
     if (!this.props.moreEntriesToFetch) return null;
 
     return <div className="view-more text-center">
             <button type="button" className="btn btn-outline-info" onClick={() => this.handleLoadMoreBtnClick()}>View more</button>
            </div>;
-  },
+  }
+
   render() {
     return (<div className="project-list">
               <div className="projects">
@@ -60,4 +57,15 @@ export default React.createClass({
               { this.renderViewMoreBtn() }
             </div>);
   }
-});
+}
+ProjectList.propTypes = {
+  entries: PropTypes.array.isRequired,
+  loadingData: PropTypes.bool.isRequired,
+  moreEntriesToFetch: PropTypes.bool.isRequired,
+  fetchData: PropTypes.func.isRequired
+};
+ProjectCard.defaultProps = {
+  entries: []
+};
+
+export { ProjectList as default };

--- a/components/project-list/project-list.jsx
+++ b/components/project-list/project-list.jsx
@@ -68,4 +68,4 @@ ProjectCard.defaultProps = {
   entries: []
 };
 
-export { ProjectList as default };
+export default ProjectList;


### PR DESCRIPTION
fixes #478 & covers some of #477 

I'm still seeing a warning about `React.PropType` but I think it's coming from the modules we are using.
<img width="752" alt="screen shot 2017-04-17 at 3 14 38 pm" src="https://cloud.githubusercontent.com/assets/2896608/25106845/a13c9fbe-2380-11e7-8ce9-086f5c7b03f6.png">
