### PR TITLE
special route for posts pending approval

### DIFF
--- a/components/hint-message/hint-message.jsx
+++ b/components/hint-message/hint-message.jsx
@@ -24,7 +24,10 @@ class HintMessage extends React.Component {
 HintMessage.propTypes = {
   header: PropTypes.string.isRequired,
   iconComponent: PropTypes.element.isRequired,
-  linkComponent: PropTypes.element.isRequired
+  linkComponent: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.element
+  ]).isRequired
 };
 
 export default HintMessage;

--- a/pages/add/add.jsx
+++ b/pages/add/add.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { browserHistory, Link } from 'react-router';
+import { Helmet } from "react-helmet";
 import { Form } from 'react-formbuilder';
 import HintMessage from '../../components/hint-message/hint-message.jsx';
 import Service from '../../js/service.js';
@@ -216,6 +217,7 @@ export default React.createClass({
   render() {
     return (
       <div className="add-page row justify-content-center">
+        <Helmet><title>Post an entry</title></Helmet>
         <div className="col-lg-8">
           { this.getContent() }
         </div>

--- a/pages/add/add.jsx
+++ b/pages/add/add.jsx
@@ -118,7 +118,6 @@ export default React.createClass({
           Service.entry
           .get(entryId)
           .then(result => {
-            console.log(result);
             if(result) {
               browserHistory.push({
                 pathname: `/entry/${response.id}`,

--- a/pages/add/add.jsx
+++ b/pages/add/add.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { browserHistory, Link } from 'react-router';
-import { Helmet } from "react-helmet";
 import { Form } from 'react-formbuilder';
 import HintMessage from '../../components/hint-message/hint-message.jsx';
 import Service from '../../js/service.js';
@@ -111,15 +110,39 @@ export default React.createClass({
 
       Service.entries
         .post(data)
-        .then((response) => {
-          browserHistory.push({
-            pathname: `/entry/${response.id}`,
-            query: {
-              justPostedByUser: true
+        .then(response => {
+          const entryId = response.id;
+
+          // will the API show this user the new entry?
+          Service.entry
+          .get(entryId)
+          .then(result => {
+            console.log(result);
+            if(result) {
+              browserHistory.push({
+                pathname: `/entry/${response.id}`,
+                query: {
+                  justPostedByUser: true
+                }
+              });
+            } else {
+              browserHistory.push({
+                pathname: `/submitted`,
+                query: { entryId }
+              });
             }
+          })
+          .catch(reason => {
+            // a 404 is yielded as an error by Service.entry
+            console.error(reason);
+            browserHistory.push({
+              pathname: `/submitted`,
+              query: { entryId }
+            });
           });
+
         })
-        .catch((reason) => {
+        .catch(reason => {
           this.setState({
             serverError: true
           });
@@ -193,7 +216,6 @@ export default React.createClass({
   render() {
     return (
       <div className="add-page row justify-content-center">
-        <Helmet><title>Add</title></Helmet>
         <div className="col-lg-8">
           { this.getContent() }
         </div>

--- a/pages/add/submitted.jsx
+++ b/pages/add/submitted.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { browserHistory, Link } from 'react-router';
+import { Helmet } from "react-helmet";
+import HintMessage from '../../components/hint-message/hint-message.jsx';
+
+const headerText = `Thanks for the submission!`;
+
+export default React.createClass({
+  getInitialState() {
+    return {
+      entryId: false
+    };
+  },
+
+  componentDidMount() {
+    let location = this.props.router.location;
+    let query = location.query;
+
+    if (query && query.entryId) {
+      let entryId = parseInt(query.entryId, 10);
+
+      // Make sure this is an entry id, and not some arbitrary data.
+      // This would be easier with != instead of !== but... linting
+      if (`${entryId}` !== query.entryId) {
+        return;
+      }
+
+      // remove 'entryId' query from URL
+      delete query.entryId;
+      browserHistory.replace({
+        pathname: location.pathname,
+        query: query
+      });
+
+      this.setState({
+        entryId: entryId
+      });
+    }
+  },
+
+  render() {
+    var linkText = false;
+
+    if (this.state.entryId) {
+      linkText = `You will be able to see to your entry via this link once approved.`;
+    }
+
+    const thankYou = (
+      <HintMessage iconComponent={<img src="/assets/svg/icon-bookmark-selected.svg" />}
+                    header={headerText}
+                    linkComponent={!linkText ? false : <Link to={`/entry/${this.state.entryId}`}>{linkText}</Link>}>
+        <p>We'll be reviewing your submission, and it'll show up in the main feed after approval.</p>
+      </HintMessage>
+    );
+
+    return (
+      <div>
+        <Helmet><title>Thank you!</title></Helmet>
+        { thankYou }
+      </div>
+    );
+  }
+});

--- a/pages/add/submitted.jsx
+++ b/pages/add/submitted.jsx
@@ -48,7 +48,7 @@ export default React.createClass({
     const thankYou = (
       <HintMessage iconComponent={<img src="/assets/svg/icon-bookmark-selected.svg" />}
                     header={headerText}
-                    linkComponent={!linkText ? false : <Link to={`/entry/${this.state.entryId}`}>{linkText}</Link>}>
+                    linkComponent={linkText ? <Link to={`/entry/${this.state.entryId}`}>{linkText}</Link> : false}>
         <p>We'll be reviewing your submission, and it'll show up in the main feed after approval.</p>
       </HintMessage>
     );

--- a/routes.jsx
+++ b/routes.jsx
@@ -10,6 +10,7 @@ import Issues from './pages/issues.jsx';
 import Issue from './pages/issue.jsx';
 import Entry from './pages/entry.jsx';
 import Add from './pages/add/add.jsx';
+import Submitted from './pages/add/submitted.jsx';
 import Search from './pages/search/search.jsx';
 import NotFound from './pages/not-found.jsx';
 
@@ -59,7 +60,7 @@ const App = React.createClass({
     document.querySelector(`#app`).classList.add(`splash-dismissed`);
     this.refs.splash.addEventListener(`transitionend`, () => {
       // wait for CSS animation to finish first before we
-      // set `suppressSplashScreen` in localStorage and 
+      // set `suppressSplashScreen` in localStorage and
       // this.state.suppressSplashScreen to true
       localstorage.setItem(`suppressSplashScreen`, `true`);
       this.setState({ suppressSplashScreen: true });
@@ -116,6 +117,7 @@ module.exports = (
     </Route>
     <Route path="entry/:entryId" component={Entry} onEnter={() => pageSettings.setScrollPosition()} onLeave={() => pageSettings.setRestore(true)} />
     <Route path="add" component={Add} />
+    <Route path="submitted" component={Submitted} />
     <Route path="search" component={Search} onEnter={evt => pageSettings.setCurrentPathname(evt.location.pathname)} />
     <Route path="tags">
       <IndexRedirect to="/latest" />


### PR DESCRIPTION
closes https://github.com/mozilla/network-pulse/issues/504, closes https://github.com/mozilla/network-pulse/issues/507

This adds in a new route for submittion entries that are not immediately set to `is_approved`.
- user hits up "add" page
- user submits entry data
- if the entry is immediately `is_approved` (e.g. this is a staff post) then the user is redirect to their entry's URL (same as before)
- if the entry is **not** immediate `is_approved` (e.g. normal user) then they are sent to `/submitted` and presented with a thank you screen and a link to where their entry will exist once we approve it.