### PR TITLE
fix event scoping and nonexistent function calls

### DIFF
--- a/components/project-card/project-card.jsx
+++ b/components/project-card/project-card.jsx
@@ -61,7 +61,6 @@ class ProjectCard extends React.Component {
     }
 
     this.setInitialBookmarkedStatus();
-
   }
 
   setInitialBookmarkedStatus() {
@@ -135,9 +134,11 @@ class ProjectCard extends React.Component {
 
   renderTitle(detailViewLink) {
     let title = this.props.title;
+
     if (!this.props.onDetailView) {
       title = <Link to={detailViewLink} onClick={this.handleTitleClick}>{title}</Link>;
     }
+
     return <h2>{title}</h2>;
   }
 
@@ -146,41 +147,59 @@ class ProjectCard extends React.Component {
 
     if (!thumbnailSource) return null;
 
-    return <Link to={detailViewLink} onClick={this.handleThumbnailClick} className="thumbnail">
-              <div className="img-container">
-                <img src={thumbnailSource} />
-              </div>
-            </Link>;
+    return (
+      <Link to={detailViewLink} onClick={this.handleThumbnailClick} className="thumbnail">
+        <div className="img-container">
+          <img src={thumbnailSource} />
+        </div>
+      </Link>
+    );
   }
 
   renderActionPanel(detailViewLink) {
-    let actionPanel = this.props.onDetailView ?
-                  (<div className="share">
-                    <a className="btn" onClick={this.handleShareBtnClick} ref={(btn) => { this.shareBtn = btn; }}></a>
-                    <input readOnly type="text" ref={(input) => { this.urlToShare = input; }} />
-                  </div>)
-                  : (<div>
-                      <Link to={detailViewLink} onClick={this.handleReadMoreClick}>Read more</Link>
-                    </div>);
-    return <div className="action-panel">
-            {actionPanel}
-            <a className="heart" ref="heart" onClick={this.toggleBookmarkedState}></a>
-          </div>;
+    let actionPanel = null;
+
+    if (this.props.onDetailView) {
+      actionPanel = (
+        <div className="share">
+          <a className="btn" onClick={evt => this.handleShareBtnClick(evt)} ref={(btn) => { this.shareBtn = btn; }}></a>
+          <input readOnly type="text" ref={(input) => { this.urlToShare = input; }} />
+        </div>
+      );
+    } else {
+      actionPanel = (
+        <div>
+          <Link to={detailViewLink} onClick={evt => this.handleReadMoreClick(evt) }>Read more</Link>
+        </div>
+      );
+    }
+
+    return (
+      <div className="action-panel">
+        {actionPanel}
+        <a className="heart" ref="heart" onClick={evt => this.toggleBookmarkedState()}></a>
+      </div>
+    );
   }
 
   renderCreatorInfo() {
     if (this.props.creators.length === 0) return null;
 
-    return <small className="creator d-block text-muted">
-             By {this.props.creators.join(`, `)}
-          </small>;
+    return (
+      <small className="creator d-block text-muted">
+         By {this.props.creators.join(`, `)}
+      </small>
+    );
   }
 
   renderTimePosted() {
     if (!this.props.created) return null;
-    return <small className="time-posted d-block text-muted">
-            Added {moment(this.props.created).format(`MMM DD, YYYY`)}
-          </small>;
+
+    return (
+      <small className="time-posted d-block text-muted">
+        Added {moment(this.props.created).format(`MMM DD, YYYY`)}
+      </small>
+    );
   }
 
   render() {
@@ -189,6 +208,7 @@ class ProjectCard extends React.Component {
       "detail-view": this.props.onDetailView,
       "bookmarked": this.state.bookmarked
     });
+
     let detailViewLink = `/entry/${this.props.id}`;
 
     return (
@@ -213,6 +233,7 @@ class ProjectCard extends React.Component {
     );
   }
 }
+
 ProjectCard.propTypes = {
   id: PropTypes.number.isRequired,
   creators: PropTypes.array,
@@ -228,6 +249,7 @@ ProjectCard.propTypes = {
   contentUrl: PropTypes.string,
   onDetailView: PropTypes.bool
 };
+
 ProjectCard.defaultProps = {
   onDetailView: false
 };

--- a/pages/bookmarks.jsx
+++ b/pages/bookmarks.jsx
@@ -30,8 +30,6 @@ export default React.createClass({
       if (pageSettings.shouldRestore) {
         // restore state back to what is stored in pageSettings
         this.setState(pageSettings.currentList);
-      } else {
-        this.fetchData();
       }
     });
 


### PR DESCRIPTION
fixes https://github.com/mozilla/network-pulse/issues/512 by resolving a scoping issue where ES6 syntax is used for JSX but the event handling does not use `evt => this.doThing(evt)` to preserve `this` scoping.  It also removes a reference to `this.fetchData()` in the bookmark page, which didn't exist and was probably a copy-paste leftover.