### PR TITLE
Track 'View more' button clicks

### DIFF
--- a/components/project-list/project-list.jsx
+++ b/components/project-list/project-list.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactGA from 'react-ga';
 import ProjectCard from '../project-card/project-card.jsx';
 import Utility from '../../js/utility.js';
 import pageSettings from '../../js/app-page-settings';
@@ -19,6 +20,11 @@ class ProjectList extends React.Component {
   }
 
   handleLoadMoreBtnClick() {
+    ReactGA.event({
+      category: `Nav Link`,
+      action: `Clicked`,
+      label: `${window.location.pathname} more`
+    });
     this.props.fetchData();
     this.setState({inPageUpdate: true});
   }


### PR DESCRIPTION
Fixes #566 
```
Category : Nav link
Action : Clicked
Label : [path] + 'more' (e.g. '/Featured more')
```


To QA:
1. checkout this PR
2. go to `js/analytics.js`
3. add `{debug: true}` to line 20
```js
  ReactGA.initialize(`UA-87658599-4`, {debug: true});
```
4. go to a project list page, e.g., /latest
5. click on the "View more" button near page bottom
6. check your browser console if there are logs like the following screencap 
<img width="519" alt="screen shot 2017-06-20 at 12 22 18 pm" src="https://user-images.githubusercontent.com/2896608/27351784-57d3cbd0-55b3-11e7-8975-d9396ed86917.png">

Ignore the weird lettercasing. We'll handle it in [this ticket](https://github.com/mozilla/network-pulse/issues/574).