### PR TITLE
Removes splash page

### DIFF
--- a/routes.jsx
+++ b/routes.jsx
@@ -40,52 +40,12 @@ const Tag = (router) => {
 
 const App = React.createClass({
   pageTitle: `Mozilla Network Pulse`,
-  getInitialState() {
-    return {
-      suppressSplashScreen: (localstorage.getItem(`suppressSplashScreen`) === `true`)
-    };
-  },
-  getDefaultProps() {
-    return {
-      dismissTimeout: 3000
-    };
-  },
-  componentDidMount() {
-    if (this.refs.splash) {
-      setTimeout(this.dismissSplash, this.props.dismissTimeout);
-    }
-  },
-  dismissSplash() {
-    this.refs.splash.classList.add(`dismissed`);
-    document.querySelector(`#app`).classList.add(`splash-dismissed`);
-    this.refs.splash.addEventListener(`transitionend`, () => {
-      // wait for CSS animation to finish first before we
-      // set `suppressSplashScreen` in localStorage and
-      // this.state.suppressSplashScreen to true
-      localstorage.setItem(`suppressSplashScreen`, `true`);
-      this.setState({ suppressSplashScreen: true });
-    });
-  },
-  renderWelcomeSplash() {
-    if (this.state.suppressSplashScreen) {
-      return null;
-    }
-    return (
-      <div id="splash" ref="splash">
-        <div className="container">
-          <div><img src="/assets/svg/pulse-wordmark.svg" width="204" height="34" alt="Mozilla Pulse" /></div>
-          <p className="mt-2">A stream of assets from peers across the Mozilla Network.</p>
-        </div>
-      </div>
-    );
-  },
   render() {
     return (
       <div>
         <Helmet titleTemplate={`%s - ${this.pageTitle}`}
                 defaultTitle={this.pageTitle}>
         </Helmet>
-        { this.renderWelcomeSplash() }
         <Navbar router={this.props.router}/>
         <div id="main" className="container">
           {this.props.children}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -67,34 +67,6 @@ button {
   }
 }
 
-#app {
-  &.splash-dismissed {
-    max-height: 100%;
-    overflow: auto;
-  }
-}
-
-#splash {
-  background: $bikeshed-magenta;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 10000;
-  color: $white;
-  transition: opacity 0.5s;
-
-  &.dismissed {
-    opacity: 0;
-    z-index: -1;
-  }
-
-  .container {
-    padding-top: 33vh;
-  }
-}
-
 #main {
   padding-top: 30px;
   padding-bottom: 420px;


### PR DESCRIPTION
Fixes #511 

@ScottDowne Alan mentioned you could help with some PR reviews so I'm assigning this one to you (thanks!) This PR should be pretty straightforward as it just removes code.

For reference, this is what the splash page looks like when user visits the site (https://mzl.la/pulse) the first time (a toggle flag is remembered in `localStorage`). Now we want to remove the splash screen altogether.
<img width="1108" alt="screen shot 2017-06-21 at 3 33 52 pm" src="https://user-images.githubusercontent.com/2896608/27409592-1c3b8b8c-5697-11e7-8004-a1b65e0fcd57.png">
