### PR TITLE
GA event cleanup

### DIFF
--- a/components/bookmark-control.jsx
+++ b/components/bookmark-control.jsx
@@ -17,7 +17,7 @@ class BookmarkControl extends React.Component {
     let config = {
       category: `Entry`,
       action: action,
-      label: `${this.props.id} - ${this.props.title}`
+      label: this.props.title
     };
 
     if (transport) {

--- a/components/bookmark-control.jsx
+++ b/components/bookmark-control.jsx
@@ -13,9 +13,9 @@ class BookmarkControl extends React.Component {
     };
   }
 
-  createGaEventConfig(category = ``, action = ``, transport = ``) {
+  createGaEventConfig(action = ``, transport = ``) {
     let config = {
-      category: `Entry Card - ${category}`,
+      category: `Entry`,
       action: action,
       label: `${this.props.id} - ${this.props.title}`
     };
@@ -96,7 +96,7 @@ class BookmarkControl extends React.Component {
       });
     }
 
-    ReactGA.event(this.createGaEventConfig(`Bookmark button`, this.state.bookmarked ? `Unbookmarked` : `Bookmarked`));
+    ReactGA.event(this.createGaEventConfig(this.state.bookmarked ? `Remove fav` : `Add fav`));
 
     if (user.loggedin) {
       this.toggleBookmark((error) => {

--- a/components/nav-link/nav-link.jsx
+++ b/components/nav-link/nav-link.jsx
@@ -12,7 +12,7 @@ class NavLink extends React.Component {
     ReactGA.event({
       category: `Nav Link`,
       action: `Clicked`,
-      label: `${this.props.to}`
+      label: this.props.to
     });
   }
 

--- a/components/project-card/meta/get-involved.jsx
+++ b/components/project-card/meta/get-involved.jsx
@@ -10,7 +10,7 @@ class GetInvolved extends React.Component {
   }
 
   handleGetInvolvedLinkClick() {
-    this.props.sendGaEvent(`Get involved`, `Clicked`, `beacon`);
+    this.props.sendGaEvent(`Get involved link tap`, `beacon`);
   }
 
   renderGetInvolvedText() {

--- a/components/project-card/meta/thumbnail.jsx
+++ b/components/project-card/meta/thumbnail.jsx
@@ -8,7 +8,7 @@ class Thumbnail extends React.Component {
   }
 
   handleThumbnailClick() {
-    this.props.sendGaEvent(`Thumbnail tap`);
+    this.props.sendGaEvent();
   }
 
   render() {

--- a/components/project-card/meta/thumbnail.jsx
+++ b/components/project-card/meta/thumbnail.jsx
@@ -8,7 +8,7 @@ class Thumbnail extends React.Component {
   }
 
   handleThumbnailClick() {
-    this.props.sendGaEvent(`Thumbnail`, `Clicked`);
+    this.props.sendGaEvent(`Thumbnail tap`);
   }
 
   render() {

--- a/components/project-card/meta/title.jsx
+++ b/components/project-card/meta/title.jsx
@@ -8,7 +8,7 @@ class Title extends React.Component {
   }
 
   handleTitleClick() {
-    this.sendGaEvent(`Title`, `Clicked`);
+    this.props.sendGaEvent(`Title tap`);
   }
 
   render() {

--- a/components/project-card/meta/title.jsx
+++ b/components/project-card/meta/title.jsx
@@ -8,7 +8,7 @@ class Title extends React.Component {
   }
 
   handleTitleClick() {
-    this.props.sendGaEvent(`Title tap`);
+    this.props.sendGaEvent();
   }
 
   render() {

--- a/components/project-card/project-card-detailed.jsx
+++ b/components/project-card/project-card-detailed.jsx
@@ -22,11 +22,11 @@ class DetailedProjectCard extends React.Component {
     };
   }
 
-  sendGaEvent(category = ``, action = ``, transport = ``) {
+  sendGaEvent(action = ``, transport = ``) {
     let config = {
-      category: `Entry Card - ${category}`,
+      category: `Entry`,
       action: action,
-      label: `${this.props.id} - ${this.props.title}`
+      label: this.props.title
     };
 
     if (transport) {
@@ -62,11 +62,11 @@ class DetailedProjectCard extends React.Component {
   }
 
   handleTwitterShareClick() {
-    this.sendGaEvent(`Twitter Share button`, `Clicked`, `beacon`);
+    this.sendGaEvent(`Twitter share tap`, `beacon`);
   }
 
   handleVisitBtnClick() {
-    this.sendGaEvent(`Visit button`, `Clicked`, `beacon`);
+    this.sendGaEvent(`Visit button tap`, `beacon`);
   }
 
   renderVisitButton() {
@@ -140,7 +140,7 @@ class DetailedProjectCard extends React.Component {
               <GetInvolved getInvolved={this.props.getInvolved}
                            getInvolvedUrl={this.props.getInvolvedUrl}
                            helpTypes={this.props.helpTypes}
-                           sendGaEvent={(category, action, transport) => this.sendGaEvent(category, action, transport)} />
+                           sendGaEvent={(action, transport) => this.sendGaEvent(action, transport)} />
             </div>;
   }
 

--- a/components/project-card/project-card-simple.jsx
+++ b/components/project-card/project-card-simple.jsx
@@ -23,11 +23,11 @@ class ProjectCard extends React.Component {
     };
   }
 
-  sendGaEvent(category = ``, action = ``, transport = ``) {
+  sendGaEvent(action = ``, transport = ``) {
     let config = {
-      category: `Entry Card - ${category}`,
+      category: `Entry`,
       action: action,
-      label: `${this.props.id} - ${this.props.title}`
+      label: this.props.title
     };
 
     if (transport) {
@@ -63,7 +63,7 @@ class ProjectCard extends React.Component {
   }
 
   handleReadMoreClick() {
-    this.sendGaEvent(`Read more`, `Clicked`);
+    this.sendGaEvent(`Read More`);
   }
 
   renderActionPanel(detailViewLink) {
@@ -97,7 +97,7 @@ class ProjectCard extends React.Component {
               <GetInvolved getInvolved={this.props.getInvolved}
                            getInvolvedUrl={this.props.getInvolvedUrl}
                            helpTypes={this.props.helpTypes}
-                           sendGaEvent={(category, action, transport) => this.sendGaEvent(category, action, transport)} />
+                           sendGaEvent={(action, transport) => this.sendGaEvent(action, transport)} />
           </div>;
   }
 
@@ -119,11 +119,11 @@ class ProjectCard extends React.Component {
           <div className="summary-content">
             <Thumbnail thumbnail={this.props.thumbnail}
                        link={!this.props.onModerationMode ? detailViewLink : ``}
-                       sendGaEvent={(category, action, transport) => this.sendGaEvent(category, action, transport)} />
+                       sendGaEvent={(action, transport) => this.sendGaEvent(action, transport)} />
             <div className="content m-3">
               <Title title={this.props.title}
                      link={!this.props.onModerationMode ? detailViewLink : ``}
-                     sendGaEvent={(category, action, transport) => this.sendGaEvent(category, action, transport)} />
+                     sendGaEvent={(action, transport) => this.sendGaEvent(action, transport)} />
               <Creators creators={this.props.creators} className="text-muted" />
               <Description description={this.props.description} />
               { this.renderExtraMeta() }

--- a/components/project-card/project-card-simple.jsx
+++ b/components/project-card/project-card-simple.jsx
@@ -119,11 +119,11 @@ class ProjectCard extends React.Component {
           <div className="summary-content">
             <Thumbnail thumbnail={this.props.thumbnail}
                        link={!this.props.onModerationMode ? detailViewLink : ``}
-                       sendGaEvent={(action, transport) => this.sendGaEvent(action, transport)} />
+                       sendGaEvent={() => this.handleReadMoreClick()} />
             <div className="content m-3">
               <Title title={this.props.title}
                      link={!this.props.onModerationMode ? detailViewLink : ``}
-                     sendGaEvent={(action, transport) => this.sendGaEvent(action, transport)} />
+                     sendGaEvent={() => this.handleReadMoreClick()} />
               <Creators creators={this.props.creators} className="text-muted" />
               <Description description={this.props.description} />
               { this.renderExtraMeta() }

--- a/components/project-list/project-list.jsx
+++ b/components/project-list/project-list.jsx
@@ -23,7 +23,7 @@ class ProjectList extends React.Component {
     ReactGA.event({
       category: `Broswe`,
       action: `View more tap`,
-      label: `${window.location.pathname}`
+      label: window.location.pathname
     });
     this.props.fetchData();
     this.setState({inPageUpdate: true});

--- a/components/project-list/project-list.jsx
+++ b/components/project-list/project-list.jsx
@@ -21,9 +21,9 @@ class ProjectList extends React.Component {
 
   handleLoadMoreBtnClick() {
     ReactGA.event({
-      category: `Nav Link`,
-      action: `Clicked`,
-      label: `${window.location.pathname} more`
+      category: `Broswe`,
+      action: `View more tap`,
+      label: `${window.location.pathname}`
     });
     this.props.fetchData();
     this.setState({inPageUpdate: true});

--- a/pages/add/add.jsx
+++ b/pages/add/add.jsx
@@ -181,7 +181,7 @@ export default React.createClass({
   getAnonymousContent() {
     let header = `Please sign in to add a post`;
     let linkComponent = <a href={user.getLoginURL(utility.getCurrentURL())}
-                           onClick={this.handleSignInBtnClick}>
+                           onClick={(event) => this.handleSignInBtnClick(event)}>
                            Sign in with Google
                         </a>;
     let additionalMessage;

--- a/pages/add/add.jsx
+++ b/pages/add/add.jsx
@@ -26,6 +26,14 @@ export default React.createClass({
       showFormInvalidNotice: false
     };
   },
+  componentWillUpdate(nextProps, nextState) {
+    if (nextState.showFormInvalidNotice) {
+      ReactGA.event({
+        category: `Add new`,
+        action: `Submit error`
+      });
+    }
+  },
   componentDidMount() {
     user.addListener(this);
     user.verify(this.props.router.location);
@@ -45,7 +53,7 @@ export default React.createClass({
     ReactGA.event({
       category: `Account`,
       action: `Login`,
-      label: window.location.pathname,
+      label: `Login ${window.location.pathname}`,
       transport: `beacon`
     });
 
@@ -57,7 +65,7 @@ export default React.createClass({
     ReactGA.event({
       category: `Account`,
       action: `Logout`,
-      label: window.location.pathname,
+      label: `Logout ${window.location.pathname}`,
     });
 
     user.logout();

--- a/pages/bookmarks.jsx
+++ b/pages/bookmarks.jsx
@@ -25,7 +25,7 @@ export default React.createClass({
     ReactGA.event({
       category: `Account`,
       action: `Login`,
-      label: window.location.pathname,
+      label: `Login ${window.location.pathname}`,
       transport: `beacon`
     });
 
@@ -37,7 +37,7 @@ export default React.createClass({
     ReactGA.event({
       category: `Account`,
       action: `Logout`,
-      label: window.location.pathname
+      label: `Logout ${window.location.pathname}`,
     });
 
     user.logout();

--- a/pages/bookmarks.jsx
+++ b/pages/bookmarks.jsx
@@ -94,7 +94,7 @@ export default React.createClass({
           </div>;
   },
   getAnonymousContent() {
-    let signInPrompt = <p><button className="btn btn-link inline-link" onClick={this.handleSignInBtnClick}>Sign in with Google</button>.</p>;
+    let signInPrompt = <p><button className="btn btn-link inline-link" onClick={(event) => this.handleSignInBtnClick(event)}>Sign in with Google</button>.</p>;
     let bookmarkedProjects = this.renderHintMessage();
 
     if (user.failedLogin) {

--- a/pages/bookmarks.jsx
+++ b/pages/bookmarks.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactGA from 'react-ga';
 import { Link } from 'react-router';
 import { Helmet } from "react-helmet";
 import classNames from 'classnames';
@@ -21,10 +22,24 @@ export default React.createClass({
   handleSignInBtnClick(event) {
     event.preventDefault();
 
+    ReactGA.event({
+      category: `Account`,
+      action: `Login`,
+      label: window.location.pathname,
+      transport: `beacon`
+    });
+
     user.login(utility.getCurrentURL());
   },
   handleLogOutBtnClick(event) {
     event.preventDefault();
+
+    ReactGA.event({
+      category: `Account`,
+      action: `Logout`,
+      label: window.location.pathname
+    });
+
     user.logout();
   },
   componentDidMount() {
@@ -88,7 +103,7 @@ export default React.createClass({
     }
 
     return <div>
-            <p className={classNames({'mb-0': !!importHint})}>Hi {user.username}! <button onClick={this.handleLogOutBtnClick} className="btn btn-link inline-link">Log out</button>.</p>
+            <p className={classNames({'mb-0': !!importHint})}>Hi {user.username}! <button onClick={(event) => this.handleLogOutBtnClick(event)} className="btn btn-link inline-link">Log out</button>.</p>
             {importHint}
             <ProjectLoader bookmarkedOnly={true} />
           </div>;

--- a/pages/search/search.jsx
+++ b/pages/search/search.jsx
@@ -77,9 +77,9 @@ class Search extends React.Component {
     let keywordsEntered = event.target.value;
 
     ReactGA.event({
-      category: `Search input box`,
+      category: `Search`,
       action: `Keywords entered`,
-      label: `${keywordsEntered}`
+      label: keywordsEntered
     });
 
     this.setState({ keywordSearched: keywordsEntered }, () => {

--- a/routes.jsx
+++ b/routes.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactGA from 'react-ga';
 import { Route, IndexRoute, IndexRedirect } from 'react-router';
 import { Helmet } from "react-helmet";
 import pageSettings from './js/app-page-settings';
@@ -20,7 +21,15 @@ import Navbar from './components/navbar/navbar.jsx';
 import Footer from './components/footer/footer.jsx';
 
 const Featured = () => {
-  let learnMore = env.LEARN_MORE_LINK ? <span><a href={env.LEARN_MORE_LINK}>Learn more</a>.</span> : null;
+  let handleOnClick = function() {
+    ReactGA.event({
+      category: `Browse`,
+      action: `About learn more tap`,
+      label: `Tagline learn more link`
+    });
+  };
+
+  let learnMore = env.LEARN_MORE_LINK ? <span><a href={env.LEARN_MORE_LINK} onClick={() => handleOnClick()}>Learn more</a>.</span> : null;
 
   return <div>
           <Helmet><title>Featured</title></Helmet>


### PR DESCRIPTION
Related to #574 
See https://docs.google.com/spreadsheets/d/1x-CP_HYaAs3oRv2cjbSFu8w5Z938E4cyHQ3hvh17c6c/edit#gid=1060389854 for the list of things we are tracking.

Some notes:

- For this pass we are tracking "submit error" whenever form validation fails. (no GA label needed for now)
- As "login" links redirect users to Google page, to test "login" related GA events you might need to set up breakpoints in debugger in order to see the logs in console.

---

To QA:
1. check out this PR
2. go to `js/analytics.js`
3. add `{debug: true}` to line 20
```js
  ReactGA.initialize(`UA-87658599-4`, {debug: true});
```
4. open your dev tool console
5. start testing
6. look for logs in the console that start with `[react-ga]` and see if the event category/action/label match what we have on [this spreadsheet](https://docs.google.com/spreadsheets/d/1x-CP_HYaAs3oRv2cjbSFu8w5Z938E4cyHQ3hvh17c6c/edit#gid=1060389854). (ignore lettercasing. GA seems to capitalize first letter of every word)

e.g.,
<img width="786" alt="screen shot 2017-08-30 at 4 44 03 pm" src="https://user-images.githubusercontent.com/2896608/29899801-79ba6480-8da2-11e7-99b6-e20d1619f8ed.png">


