### PR TITLE
Keyboard should auto dismiss after user hit go/search

### DIFF
--- a/pages/search/search.jsx
+++ b/pages/search/search.jsx
@@ -104,7 +104,7 @@ class Search extends React.Component {
 
     return <div className="d-flex align-items-center">
             <div className={classnames}>
-              <form action="for-search-key-to-show-on-mobile-keyboard">
+              <form action="for-search-key-to-show-on-mobile-keyboard" role="search">
                 <DebounceInput id="search-box"
                                 value={this.state.keywordSearched}
                                 debounceTimeout={300}

--- a/pages/search/search.jsx
+++ b/pages/search/search.jsx
@@ -104,14 +104,16 @@ class Search extends React.Component {
 
     return <div className="d-flex align-items-center">
             <div className={classnames}>
-              <DebounceInput id="search-box"
-                              value={this.state.keywordSearched}
-                              debounceTimeout={300}
-                              type="search"
-                              onChange={(event) => this.handleInputChange(event)}
-                              placeholder="Search keywords, people, tags..."
-                              className="form-control"
-              />
+              <form action="for-search-key-to-show-on-mobile-keyboard">
+                <DebounceInput id="search-box"
+                                value={this.state.keywordSearched}
+                                debounceTimeout={300}
+                                type="search"
+                                onChange={(event) => this.handleInputChange(event)}
+                                placeholder="Search keywords, people, tags..."
+                                className="form-control"
+                />
+              </form>
               <button className="btn dismiss" onClick={() => this.handleDismissBtnClick()}>&times;</button>
             </div>
           </div>;


### PR DESCRIPTION
Fixes #492 

@alanmoo @gvn I don't have an Android device with me. Can either of you help check? This works fine on iOS 10 latest Safari/FF/Chrome.

To QA,

1. check out this PR
2. `npm start` the app
3. ngrok it so you can visit the app on your mobile
4. go to the search page (by tapping the search icon on the nav)
5. type something in the input box, see if the default "return" key (not sure what the Android equivalent is called) becomes "Go/Search"
6. type in some text and hit that "Go/Search" key, see if keyboard gets auto dismissed after

(note that you won't be seeing any projects unless your ngork instance is whitelisted by the api)

