### PR TITLE
Edit profile page UI only

### DIFF
--- a/components/form-fields/help-types.jsx
+++ b/components/form-fields/help-types.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import DynamicCheckboxGroup from './dynamic-checkbox-group.jsx';
+import Service from '../../js/service';
+
+class HelpTypes extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { options: [] };
+  }
+  componentWillMount() {
+    Service.helpTypes.get().then(options => {
+      this.setState({ options: options.map(option => option.name) });
+    });
+  }
+  render() {
+    return <DynamicCheckboxGroup options={this.state.options} onChange={this.props.onChange} colNum={2} />;
+  }
+}
+
+export default HelpTypes;

--- a/components/form-fields/help-types.jsx
+++ b/components/form-fields/help-types.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import DynamicCheckboxGroup from './dynamic-checkbox-group.jsx';
 import Service from '../../js/service';
 
-class HelpTypes extends React.Component {
+class HelpTypesField extends React.Component {
   constructor(props) {
     super(props);
     this.state = { options: [] };
@@ -17,4 +17,4 @@ class HelpTypes extends React.Component {
   }
 }
 
-export default HelpTypes;
+export default HelpTypesField;

--- a/components/form-fields/issues.jsx
+++ b/components/form-fields/issues.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import DynamicCheckboxGroup from './dynamic-checkbox-group.jsx';
 import Service from '../../js/service';
 
-class Issues extends React.Component {
+class IssuesField extends React.Component {
   constructor(props) {
     super(props);
     this.state = { options: [] };
@@ -17,4 +17,4 @@ class Issues extends React.Component {
   }
 }
 
-export default Issues;
+export default IssuesField;

--- a/components/form-fields/issues.jsx
+++ b/components/form-fields/issues.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import DynamicCheckboxGroup from './dynamic-checkbox-group.jsx';
+import Service from '../../js/service';
+
+class Issues extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { options: [] };
+  }
+  componentWillMount() {
+    Service.issues.get().then(options => {
+      this.setState({ options: options.map(option => option.name) });
+    });
+  }
+  render() {
+    return <DynamicCheckboxGroup options={this.state.options} onChange={this.props.onChange} />;
+  }
+}
+
+export default Issues;

--- a/js/app-user.js
+++ b/js/app-user.js
@@ -39,7 +39,7 @@ const Login = {
     // verify user's logged in status with Pulse API
     Service.userstatus()
       .then(response => {
-        setUserData(false, response.username, response.moderator);
+        setUserData(false, response.username, response.email, response.moderator);
       })
       .catch(reason => {
         console.error(reason);
@@ -82,6 +82,7 @@ class User {
 
   resetUser(justLoggedOut) {
     this.username = undefined;
+    this.email = undefined;
     this.loggedin = justLoggedOut ? false : undefined;
     this.moderator = false;
     this.failedLogin = false;
@@ -120,8 +121,8 @@ class User {
   }
 
   verify(location) {
-    Login.isLoggedIn(location, (error, username, moderator) => {
-      this.update(error, username, moderator);
+    Login.isLoggedIn(location, (error, username, email, moderator) => {
+      this.update(error, username, email, moderator);
     });
   }
 
@@ -136,7 +137,7 @@ class User {
     });
   }
 
-  update(error, username=false, moderator=false) {
+  update(error, username=false, email=false, moderator=false) {
     if (error) {
       console.log(`login error:`, error);
     }
@@ -153,6 +154,7 @@ class User {
     this.loggedin = !!username;
     this.moderator = !!moderator;
     this.username = username;
+    this.email = email;
 
     // notify listeners that this user logged in state has been verified
     this.notifyListeners(`verified`);

--- a/pages/add/add.scss
+++ b/pages/add/add.scss
@@ -1,187 +1,143 @@
 .add-page {
-  h1,
-  h2 {
-    color: $bikeshed-magenta;
-    margin-bottom: 0.5rem;
+  .posted-by {
+    margin-top: $form-field-vertical-margin / 2;
   }
 
-  h1 {
-    font-size: 2.25rem;
-  }
+  fieldset.creators {
+    .row {
+      vertical-align: middle;
+      margin: 0 0 0.5rem;
 
-  h2 {
-    font-size: 1.5rem;
-    font-weight: 400;
-    margin-top: $form-field-vertical-margin;
-  }
-}
+      @media screen and (min-width: $bp-md) {
+        display: inline-block;
+        width: calc(50% - 0.5rem / 2);
 
-.checkboxGroup {
-  label {
-    @extend .form-check-label;
-
-    margin-left: 0;
-  }
-
-  input {
-    @extend .form-check-input;
-
-    margin-right: 0.5rem;
-  }
-
-  .options {
-    column-width: $bp-sm;
-
-    @media screen and (min-width: $bp-md) {
-      column-width: calc(#{$bp-sm} / 2);
+        &:nth-child(2n) {
+          margin-left: 0.5rem;
+        }
+      }
     }
-  }
-}
 
-.posted-by {
-  margin-top: $form-field-vertical-margin / 2;
+    .button {
+      outline: none;
+    }
 
-  .user-full-name {
-    display: inline-block;
-    margin-left: 5px;
-  }
-}
+    .button.remove-field {
+      display: none;
+    }
 
-fieldset.creators {
-  .row {
-    vertical-align: middle;
-    margin: 0 0 0.5rem;
+    .button.add-field {
+      @extend .btn-link;
 
-    @media screen and (min-width: $bp-md) {
-      display: inline-block;
-      width: calc(50% - 0.5rem / 2);
+      margin-left: 1rem;
 
-      &:nth-child(2n) {
-        margin-left: 0.5rem;
+      @include hover-focus {
+        color: $link-hover-color;
       }
     }
   }
 
-  .button {
-    outline: none;
-  }
-
-  .button.remove-field {
-    display: none;
-  }
-
-  .button.add-field {
-    @extend .btn-link;
-
-    margin-left: 1rem;
-
-    @include hover-focus {
-      color: $link-hover-color;
-    }
-  }
-}
-
-fieldset.thumbnail {
-  .help-text {
-    margin-left: 1rem;
-    color: $gray-light;
-  }
-}
-
-.submit-section {
-  margin-top: $form-field-vertical-margin;
-
-  button + span {
-    color: $form-error-color;
-  }
-}
-
-.tags {
-  .react-tags {
-    position: relative;
-    cursor: text;
-  }
-
-  .react-tags.is-focused {
-    border-color: $gray-lightest;
-  }
-
-  .react-tags__selected {
-    display: inline;
-  }
-
-  .selected-tag {
-    display: inline-block;
-    background: $off-white;
-
-    &::after {
-      content: '\2715';
-      color: $gray;
-      margin-left: 0.5rem;
-    }
-
-    &:hover,
-    &:focus {
-      border-color: $gray-lighter;
+  fieldset.thumbnail {
+    .help-text {
+      margin-left: 1rem;
+      color: $gray-light;
     }
   }
 
-  .search {
-    display: inline-block;
-    max-width: 100%; // prevent autoresize overflowing the container
+  .submit-section {
+    margin-top: $form-field-vertical-margin;
 
-    input {
-      @extend .form-control;
-
-      max-width: 100%; // prevent autoresize overflowing the container
-      height: 100%;
-      padding: 0;
-      border: 0;
-      outline: none;
+    button + span {
+      color: $form-error-color;
     }
   }
 
-  .suggestions {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    width: 100%;
-
-    ul {
-      padding: 0;
-      list-style: none;
-      background: $white;
-      border: 1px solid $gray-lighter;
-      border-radius: $btn-border-radius;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  .tags {
+    .react-tags {
+      position: relative;
+      cursor: text;
     }
 
-    li {
-      border-bottom: 1px solid $gray-lighter;
-      padding: 6px 8px;
-      margin: 0;
+    .react-tags.is-focused {
+      border-color: $gray-lightest;
+    }
 
-      &:hover {
-        cursor: pointer;
+    .react-tags__selected {
+      display: inline;
+    }
+
+    .selected-tag {
+      display: inline-block;
+      background: $off-white;
+
+      &::after {
+        content: '\2715';
+        color: $gray;
+        margin-left: 0.5rem;
       }
 
       &:hover,
-      &.is-active {
-        background: $gray-lightest;
+      &:focus {
+        border-color: $gray-lighter;
+      }
+    }
+
+    .search {
+      display: inline-block;
+      max-width: 100%; // prevent autoresize overflowing the container
+
+      input {
+        @extend .form-control;
+
+        max-width: 100%; // prevent autoresize overflowing the container
+        height: 100%;
+        padding: 0;
+        border: 0;
+        outline: none;
+      }
+    }
+
+    .suggestions {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      width: 100%;
+
+      ul {
+        padding: 0;
+        list-style: none;
+        background: $white;
+        border: 1px solid $gray-lighter;
+        border-radius: $btn-border-radius;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
       }
 
-      &.is-disabled {
-        opacity: 0.5;
-        cursor: auto;
-      }
+      li {
+        border-bottom: 1px solid $gray-lighter;
+        padding: 6px 8px;
+        margin: 0;
 
-      mark {
-        text-decoration: underline;
-        background: none;
-        font-weight: 600;
-        padding-right: 0;
+        &:hover {
+          cursor: pointer;
+        }
+
+        &:hover,
+        &.is-active {
+          background: $gray-lightest;
+        }
+
+        &.is-disabled {
+          opacity: 0.5;
+          cursor: auto;
+        }
+
+        mark {
+          text-decoration: underline;
+          background: none;
+          font-weight: 600;
+          padding-right: 0;
+        }
       }
     }
   }
 }
-

--- a/pages/add/form/detail-info-fields.js
+++ b/pages/add/form/detail-info-fields.js
@@ -1,25 +1,10 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ReactTags from 'react-tag-autocomplete';
-import DynamicCheckboxGroup from '../../../components/form-fields/dynamic-checkbox-group.jsx';
+import IssuesField from '../../../components/form-fields/issues.jsx';
 import validator from './validator';
 import Service from '../../../js/service';
 
 const DELIMITERS = [9,13,188]; // keycodes for tab,enter,comma
-
-class Issues extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { options: [] };
-  }
-  componentWillMount() {
-    Service.issues.get().then(options => {
-      this.setState({ options: options.map(option => option.name) });
-    });
-  }
-  render() {
-    return <DynamicCheckboxGroup options={this.state.options} onChange={this.props.onChange} />;
-  }
-}
 
 let Tags = React.createClass({
   getInitialState() {
@@ -117,7 +102,7 @@ module.exports = {
     validator: validator.maxLengthValidator(300)
   },
   issues: {
-    type: Issues,
+    type: IssuesField,
     label: `Check any Key Internet Issues that relate to your project.`,
     colCount: 1
   },

--- a/pages/add/form/get-help-fields.js
+++ b/pages/add/form/get-help-fields.js
@@ -1,22 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import validator from './validator';
-import DynamicCheckboxGroup from '../../../components/form-fields/dynamic-checkbox-group.jsx';
-import Service from '../../../js/service';
-
-class HelpTypes extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { options: [] };
-  }
-  componentWillMount() {
-    Service.helpTypes.get().then(options => {
-      this.setState({ options: options.map(option => option.name) });
-    });
-  }
-  render() {
-    return <DynamicCheckboxGroup options={this.state.options} onChange={this.props.onChange} colNum={2} />;
-  }
-}
+import HelpTypesField from '../../../components/form-fields/help-types.jsx';
 
 let fields = {
   'get_involved': {
@@ -27,7 +11,7 @@ let fields = {
     validator: validator.maxLengthValidator(300)
   },
   'help_types': {
-    type: HelpTypes,
+    type: HelpTypesField,
     label: `Pick up to 3 ways that people can help.`,
   },
   'get_involved_url': {

--- a/pages/profile-edit/form/fields.js
+++ b/pages/profile-edit/form/fields.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Link } from 'react-router';
+import IssuesField from '../../../components/form-fields/issues.jsx';
+import HelpTypesField from '../../../components/form-fields/help-types.jsx';
+
+// FIXME:TO: field names are subject to changes. Once we figure out what fields backend is accepting.
+
+let IssuesLabel = () => {
+  return <div>Your <Link to="/issues" target="_blank">Key Internet Issues</Link> interest.</div>;
+};
+
+module.exports = {
+  "city_country": {
+    type: `text`,
+    label: `City, Country`,
+    placeholder: `Vancouver, Canada`,
+    fieldClassname: `form-control`,
+    validator: []
+  },
+  "languages": {
+    type: `text`,
+    label: `Languages`,
+    placeholder: `English, Türkçe`,
+    fieldClassname: `form-control`,
+    validator: []
+  },
+  "bio": {
+    type: `textarea`,
+    label: `Bio`,
+    placeholder: `About you`,
+    fieldClassname: `form-control`,
+    validator: []
+  },
+  "twitter": {
+    type: `text`,
+    label: `Twitter`,
+    placeholder: `https://twitter.com/username`,
+    fieldClassname: `form-control`,
+    validator: []
+  },
+  "linkedin": {
+    type: `text`,
+    label: `LinkedIn`,
+    placeholder: `https://linkedin.com/in/username`,
+    fieldClassname: `form-control`,
+    validator: []
+  },
+  "github": {
+    type: `text`,
+    label: `GitHub`,
+    placeholder: `https://github.com/username`,
+    fieldClassname: `form-control`,
+    validator: []
+  },
+  "website": {
+    type: `text`,
+    label: `Your website URL`,
+    placeholder: `https://example.com`,
+    fieldClassname: `form-control`,
+    validator: []
+  },
+  "thumbnail": {
+    type: `image`,
+    label: `Profile pic`,
+    prompt: `Select image`,
+    fieldClassname: `form-control`,
+    validator: []
+  },
+  "issues": {
+    type: IssuesField,
+    label: <IssuesLabel />,
+    colCount: 1
+  },
+  "help_types": {
+    type: HelpTypesField,
+    label: `You can help other people with.`,
+  },
+  "show_fav": {
+    type: `checkboxGroup`,
+    label: `Allow anyone to see a list of posts I have favoritied.`,
+    options: [ `Yes, please show my favs` ],
+    colCount: 1
+  }
+};

--- a/pages/profile-edit/profile-edit.jsx
+++ b/pages/profile-edit/profile-edit.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { browserHistory } from 'react-router';
 import { Helmet } from "react-helmet";
 import { Form } from 'react-formbuilder';
+import HintMessage from '../../components/hint-message/hint-message.jsx';
 import utility from '../../js/utility';
 import user from '../../js/app-user';
 import fields from './form/fields';
@@ -29,13 +31,17 @@ export default React.createClass({
   },
   handleSignInBtnClick(event) {
     event.preventDefault();
-    // TODO:FIXME
-    // placeholder event handler
+
+    user.login(utility.getCurrentURL());
   },
   handleLogOutBtnClick(event) {
     event.preventDefault();
     // TODO:FIXME
     // placeholder event handler
+    user.logout();
+    browserHistory.push({
+      pathname: `/featured`
+    });
   },
   handleFormUpdate() {
     // TODO:FIXME
@@ -47,9 +53,6 @@ export default React.createClass({
     // placeholder event handler
   },
   getContentForLoggedInUser() {
-    let authErrorMessage = this.state.authError ? <span className="error">You seem to be logged out at this moment. Try <a href={user.getLoginURL(utility.getCurrentURL())}>logging in</a> again?</span> : null;
-    let serverErrorMessage = this.state.serverError ? <span className="error">Sorry! We're unable to submit entry to server at this time.</span> : null;
-
     return( <div className="row">
               <div className="col-12">
                 <h1>Your profile</h1>
@@ -60,7 +63,7 @@ export default React.createClass({
                     <span>Email <em>(email won't be displayed or shared)</em></span>
                     <div className="text-muted">
                       <span>{user.email}</span>
-                      <span className="d-block d-sm-inline-block ml-0 ml-sm-4"><button className="btn btn-link inline-link" onClick={this.handleLogOutBtnClick}>Sign out</button></span>
+                      <span className="d-block d-sm-inline-block ml-0 ml-sm-4"><button className="btn btn-link inline-link" onClick={(event) => this.handleLogOutBtnClick(event)}>Sign out</button></span>
                     </div>
                   </div>
                   <div className="mb-3">
@@ -81,9 +84,6 @@ export default React.createClass({
                     onClick={this.handleFormSubmit}
                     disabled={this.state.submitting ? `disabled` : null}
                   >{ this.state.submitting ? SUBMITTING_LABEL : PRE_SUBMIT_LABEL }</button>
-                  { authErrorMessage }
-                  { serverErrorMessage }
-                  { this.state.showFormInvalidNotice && <span>Something isn't right. Check your info above.</span> }
                 </div>
               </div>
             </div>);

--- a/pages/profile-edit/profile-edit.jsx
+++ b/pages/profile-edit/profile-edit.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { Helmet } from "react-helmet";
+import { Form } from 'react-formbuilder';
+import utility from '../../js/utility';
+import user from '../../js/app-user';
+import fields from './form/fields';
+
+const PRE_SUBMIT_LABEL = `Submit`;
+const SUBMITTING_LABEL = `Submitting...`;
+
+export default React.createClass({
+  getInitialState() {
+    return {
+      user
+    };
+  },
+  componentDidMount() {
+    user.addListener(this);
+    user.verify(this.props.router.location);
+  },
+  componentWillUnmount() {
+    user.removeListener(this);
+  },
+  updateUser(event) {
+    // this updateUser method is called by "user" after changes in the user state happened
+    if (event === `verified` ) {
+      this.setState({ user });
+    }
+  },
+  handleSignInBtnClick(event) {
+    event.preventDefault();
+    // TODO:FIXME
+    // placeholder event handler
+  },
+  handleLogOutBtnClick(event) {
+    event.preventDefault();
+    // TODO:FIXME
+    // placeholder event handler
+  },
+  handleFormUpdate() {
+    // TODO:FIXME
+    // placeholder event handler
+  },
+  handleFormSubmit(event) {
+    event.preventDefault();
+    // TODO:FIXME
+    // placeholder event handler
+  },
+  getContentForLoggedInUser() {
+    let authErrorMessage = this.state.authError ? <span className="error">You seem to be logged out at this moment. Try <a href={user.getLoginURL(utility.getCurrentURL())}>logging in</a> again?</span> : null;
+    let serverErrorMessage = this.state.serverError ? <span className="error">Sorry! We're unable to submit entry to server at this time.</span> : null;
+
+    return( <div className="row">
+              <div className="col-12">
+                <h1>Your profile</h1>
+                <p>[FIXME] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque posuere a magna a vulputate. Morbi vel odio tincidunt sem pulvinar dapibus ut at odio <span style={{color: `red`}}>link to legal</span>.</p>
+                <p>All fields are optional.</p>
+                <div className="mb-4">
+                  <div className="mb-3">
+                    <span>Email <em>(email won't be displayed or shared)</em></span>
+                    <div className="text-muted">
+                      <span>{user.email}</span>
+                      <span className="d-block d-sm-inline-block ml-0 ml-sm-4"><button className="btn btn-link inline-link" onClick={this.handleLogOutBtnClick}>Sign out</button></span>
+                    </div>
+                  </div>
+                  <div className="mb-3">
+                    <span>User name</span>
+                    <div className="text-muted">
+                      <span>{user.username}</span>
+                    </div>
+                  </div>
+                </div>
+                <Form ref="form" fields={fields}
+                                   inlineErrors={true}
+                                   onUpdate={(event) => this.handleFormUpdate(event)}
+                                   className="row" />
+                <div className="submit-section">
+                  <button
+                    className="btn btn-info mr-3"
+                    type="submit"
+                    onClick={this.handleFormSubmit}
+                    disabled={this.state.submitting ? `disabled` : null}
+                  >{ this.state.submitting ? SUBMITTING_LABEL : PRE_SUBMIT_LABEL }</button>
+                  { authErrorMessage }
+                  { serverErrorMessage }
+                  { this.state.showFormInvalidNotice && <span>Something isn't right. Check your info above.</span> }
+                </div>
+              </div>
+            </div>);
+  },
+  getAnonymousContent() {
+    let header = `Please sign in to edit your profile.`;
+    let linkComponent = <a href={user.getLoginURL(utility.getCurrentURL())}
+                           onClick={(event) => this.handleSignInBtnClick(event)}>
+                           Sign in with Google
+                        </a>;
+    let additionalMessage;
+
+    if (user.failedLogin) {
+      header = `Sign in failed`;
+      linkComponent = <Link to={`/featured`}>Explore featured</Link>;
+      additionalMessage = <p>Sorry, login failed! Please try again or <a href="mailto:https://mzl.la/pulse-contact">contact us</a>.</p>;
+    }
+
+    return <HintMessage iconComponent={<span className={`fa fa-user`}></span>}
+                         header={header}
+                         linkComponent={linkComponent}>
+              {additionalMessage}
+            </HintMessage>;
+  },
+  getContent() {
+    if (user.loggedin === undefined) return null;
+
+    if (user.loggedin) return this.getContentForLoggedInUser();
+
+    return this.getAnonymousContent();
+  },
+  render() {
+    return (
+      <div className="profile-edit-page row justify-content-center">
+        <Helmet><title>Update profile</title></Helmet>
+        <div className="col-lg-8">
+          { this.getContent() }
+        </div>
+      </div>
+    );
+  }
+});

--- a/pages/profile-edit/profile-edit.scss
+++ b/pages/profile-edit/profile-edit.scss
@@ -1,0 +1,13 @@
+.profile-edit-page {
+  fieldset {
+    @extend .fieldset-full-width;
+  }
+
+  fieldset.city_country,
+  fieldset.languages,
+  fieldset.twitter,
+  fieldset.linkedin,
+  fieldset.github {
+    @extend .fieldset-half-width;
+  }
+}

--- a/routes.jsx
+++ b/routes.jsx
@@ -15,6 +15,7 @@ import Add from './pages/add/add.jsx';
 import Submitted from './pages/add/submitted.jsx';
 import Search from './pages/search/search.jsx';
 import Moderation from './pages/moderation.jsx';
+import ProfileEdit from './pages/profile-edit/profile-edit.jsx';
 import NotFound from './pages/not-found.jsx';
 
 import Navbar from './components/navbar/navbar.jsx';
@@ -110,6 +111,7 @@ module.exports = (
       <Route path=":helpType" component={Help} onEnter={evt => pageSettings.setCurrentPathname(evt.location.pathname)} />
     </Route>
     <Route path="moderation" component={Moderation} onEnter={evt => pageSettings.setCurrentPathname(evt.location.pathname)} />
+    <Route path="myprofile" component={ProfileEdit} onEnter={evt => pageSettings.setCurrentPathname(evt.location.pathname)} />
     <Route path="*" component={NotFound}/>
   </Route>
 );

--- a/scss/form.scss
+++ b/scss/form.scss
@@ -1,0 +1,23 @@
+// most of the following CSS rules are to style form elements created by the "react-formbuilder" library
+
+.checkboxGroup {
+  label {
+    @extend .form-check-label;
+
+    margin-left: 0;
+  }
+
+  input {
+    @extend .form-check-input;
+
+    margin-right: 0.5rem;
+  }
+}
+
+.fieldset-full-width {
+  @extend .col-12;
+}
+
+.fieldset-half-width {
+  @extend .col-md-6;
+}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -8,6 +8,7 @@
 @import '../node_modules/mofo-bootstrap/src/scss/overrides/mixins.scss';
 @import '../node_modules/bootstrap/scss/buttons.scss';
 @import '../node_modules/bootstrap/scss/forms.scss';
+@import '../node_modules/bootstrap/scss/grid.scss';
 @import '../node_modules/react-select/scss/default.scss';
 
 // mixins
@@ -175,6 +176,27 @@ textarea {
   }
 }
 
+.add-page,
+.profile-edit-page {
+  h1,
+  h2 {
+    color: $bikeshed-magenta;
+    margin-bottom: 0.5rem;
+  }
+
+  h1 {
+    font-size: 2.25rem;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin-top: $form-field-vertical-margin;
+  }
+}
+
+@import 'form';
+
 // Components
 
 @import '../components/navbar/navbar';
@@ -188,3 +210,4 @@ textarea {
 @import '../pages/add/add';
 @import '../pages/search/search';
 @import '../pages/issues/issues';
+@import '../pages/profile-edit/profile-edit';


### PR DESCRIPTION
❗️ **This is a feature branch against another feature branch `edit-profile-page`.**

Related to #626 .
Mockup: https://redpen.io/bk7c2a3cbaafdcd47a

Instead of filing a huuuuuuuuuge PR I'm trying to tackle #626 in stages. This PR **only** covers the following

- added the route `/myprofile`
- added UI elements to the `/myprofile` page (no functionality, just making sure fields are there in the form)
- some CSS refactor and changes

Functionality bits like event handlers related to the form submission and form validations are not covered in this PR.

Note:
To log in locally... log in via http://test.example.com:8000/admin/login/?next=/admin/ instead. The "sign in" link on Pulse front end doesn't work locally due to some Google Client setup (I can't recall the actual reason. Will need to get insights from Pomax on this)