### PR TITLE
Link entry submitter's name to profile page

### DIFF
--- a/components/bio/bio.jsx
+++ b/components/bio/bio.jsx
@@ -121,7 +121,7 @@ class Bio extends React.Component {
 Bio.propTypes = {
   name: PropTypes.string.isRequired,
   "custom_name": PropTypes.string.isRequired,
-  thumbnail: PropTypes.string.isRequired,
+  thumbnail: PropTypes.string,
   issues: PropTypes.array.isRequired,
   twitter: PropTypes.string.isRequired,
   linkedin: PropTypes.string.isRequired,

--- a/components/project-card/project-card-detailed.jsx
+++ b/components/project-card/project-card-detailed.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 import ReactGA from 'react-ga';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -83,7 +84,7 @@ class DetailedProjectCard extends React.Component {
     if (!this.props.created && !this.props.publishedBy) return null;
 
     let timePosted = this.props.created ? ` ${moment(this.props.created).format(`MMM DD, YYYY`)}` : null;
-    let publishedBy = this.props.publishedBy ? <span> by {this.props.publishedBy}</span> : null;
+    let publishedBy = this.props.publishedBy ? <span> by <Link to={`/profile/${this.props.submitterProfileId}`}>{this.props.publishedBy}</Link></span> : null;
 
     return (
       <p><small className="time-posted d-block">

--- a/js/service.js
+++ b/js/service.js
@@ -243,8 +243,11 @@ let Service = {
   userstatus: function() {
     return getDataFromURL(`${pulseAPI}/userstatus/`);
   },
-  profileMe: function () {
+  profileMe: function() {
     return getDataFromURL(`${pulseAPI}/profiles/me/`);
+  },
+  profile: function(id) {
+    return getDataFromURL(`${pulseAPI}/profiles/${id}/`);
   },
   nonce: function() {
     return getDataFromURL(`${pulseAPI}/nonce/`);

--- a/pages/profile.jsx
+++ b/pages/profile.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Helmet } from "react-helmet";
-import Service from '../js/service.js';
 import Bio from '../components/bio/bio.jsx';
 import ProjectList from '../components/project-list/project-list.jsx';
 import pageSettings from '../js/app-page-settings';
@@ -8,35 +7,20 @@ import pageSettings from '../js/app-page-settings';
 class Profile extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      userProfile: null,
-      userProfileLoaded: false
-    };
-  }
-
-  componentDidMount() {
-    Service.profileMe()
-      .then(userProfile => {
-        this.setState({ userProfile, userProfileLoaded: true });
-      })
-      .catch(reason => {
-        console.error(reason);
-      });
   }
 
   renderProfile() {
-    if (!this.state.userProfileLoaded) return null;
+    if (!this.props.profile) return null;
 
-    return <div className="col-12"><Bio {...this.state.userProfile} /></div>;
+    return <div className="col-12"><Bio {...this.props.profile} /></div>;
   }
 
   renderProjects() {
-    if (!this.state.userProfileLoaded) return null;
-    if (this.state.userProfileLoaded && this.state.userProfile.published_entries.length < 1) return null;
+    if (!this.props.profile || this.props.profile.published_entries.length < 1) return null;
 
     return <div className="col-12">
       {/* TODO:FIXME: for now let's just render all entries at once. (no 'view more' button) I will file another PR to refine this. */}
-      <ProjectList entries={this.state.userProfile.published_entries}
+      <ProjectList entries={this.props.profile.published_entries}
         loadingData={false}
         moreEntriesToFetch={false}
         fetchData={()=>{}}

--- a/routes.jsx
+++ b/routes.jsx
@@ -3,6 +3,7 @@ import ReactGA from 'react-ga';
 import { Route, IndexRoute, IndexRedirect } from 'react-router';
 import { Helmet } from "react-helmet";
 import pageSettings from './js/app-page-settings';
+import Service from './js/service.js';
 import env from "./config/env.generated.json";
 
 import ProjectLoader from './components/project-loader/project-loader.jsx';
@@ -56,6 +57,52 @@ const Tag = (router) => {
   let searchParam = { key: `tag`, value: router.params.tag };
   return <SingleFilterCriteriaPage searchParam={searchParam} headerLabel="Tag" />;
 };
+
+class MyProfile extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      userProfile: null
+    };
+  }
+
+  componentDidMount() {
+    Service.profileMe()
+      .then(userProfile => {
+        this.setState({ userProfile });
+      })
+      .catch(reason => {
+        console.error(reason);
+      });
+  }
+
+  render() {
+    return <Profile profile={this.state.userProfile} />;
+  }
+}
+
+class PublicProfile extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      userProfile: null
+    };
+  }
+
+  componentDidMount() {
+    Service.profile(this.props.params.id)
+      .then(userProfile => {
+        this.setState({ userProfile });
+      })
+      .catch(reason => {
+        console.error(reason);
+      });
+  }
+
+  render() {
+    return <Profile profile={this.state.userProfile} />;
+  }
+}
 
 class App extends React.Component {
   constructor(props) {
@@ -112,7 +159,8 @@ module.exports = (
     </Route>
     <Route path="moderation" component={Moderation} onEnter={evt => pageSettings.setCurrentPathname(evt.location.pathname)} />
     <Route path="profile">
-      <Route path="me" component={Profile} onEnter={evt => pageSettings.setCurrentPathname(evt.location.pathname)} />
+      <Route path="me" component={MyProfile} onEnter={evt => pageSettings.setCurrentPathname(evt.location.pathname)} />
+      <Route path=":id" component={PublicProfile} onEnter={evt => pageSettings.setCurrentPathname(evt.location.pathname)} />
     </Route>
     <Route path="myprofile" component={ProfileEdit} onEnter={evt => pageSettings.setCurrentPathname(evt.location.pathname)} />
     <Route path="*" component={NotFound}/>


### PR DESCRIPTION
(Note: this is a feature branch on top of the WIP `all-things-profile-related` branch)

Fixes #625 


To test,

1. Go to a detail entry page (e.g, http://localhost:3000/entry/55 )
2. Near the bottom of the left column you will see a line like `Added [date posted] by [name]`
3. Click on the [name] and see if that brings you to that person's profile page