### PR TITLE
Profile pages - 404 and 'please log in' handling

### DIFF
--- a/components/hint-message/hint-message.jsx
+++ b/components/hint-message/hint-message.jsx
@@ -12,7 +12,7 @@ class HintMessage extends React.Component {
   render() {
     return (
       <div className="hint-message text-center">
-        <div className="icon mb-3">{ this.props.iconComponent }</div>
+        <h2 className="icon mb-3">{ this.props.iconComponent }</h2>
         <h2>{ this.props.header }</h2>
         { this.props.children }
         { this.renderLink() }

--- a/components/hint-message/hint-message.jsx
+++ b/components/hint-message/hint-message.jsx
@@ -12,7 +12,7 @@ class HintMessage extends React.Component {
   render() {
     return (
       <div className="hint-message text-center">
-        <h2>{ this.props.iconComponent }</h2>
+        <div className="icon mb-3">{ this.props.iconComponent }</div>
         <h2>{ this.props.header }</h2>
         { this.props.children }
         { this.renderLink() }

--- a/components/hint-message/hint-message.scss
+++ b/components/hint-message/hint-message.scss
@@ -1,6 +1,11 @@
 .hint-message {
   margin-top: 2rem;
 
+  h2 {
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+
   @media screen and (min-width: $bp-md) {
     margin-top: 5rem;
   }

--- a/components/loading-notice.jsx
+++ b/components/loading-notice.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default () => {
+  // 3 empty <div></div> here are for the loading animation dots (done in CSS) to show.
+  return <div className="loading my-5 d-flex justify-content-center align-items-center">
+              <div></div>
+              <div></div>
+              <div></div>
+            </div>;
+};

--- a/components/project-list/project-list.jsx
+++ b/components/project-list/project-list.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactGA from 'react-ga';
+import LoadingNotice from '../loading-notice.jsx';
 import ProjectCardSimple from '../project-card/project-card-simple.jsx';
 import Utility from '../../js/utility.js';
 import pageSettings from '../../js/app-page-settings';
@@ -38,12 +39,7 @@ class ProjectList extends React.Component {
   renderLoadingNotice() {
     if (!this.props.loadingData ) return null;
 
-    // 3 empty <div></div> here are for the loading animation dots (done in CSS) to show.
-    return <div className="loading my-5 d-flex justify-content-center align-items-center">
-              <div></div>
-              <div></div>
-              <div></div>
-            </div>;
+    return <LoadingNotice />;
   }
 
   renderViewMoreBtn() {

--- a/pages/entry.jsx
+++ b/pages/entry.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { browserHistory } from 'react-router';
 import { Helmet } from "react-helmet";
+import LoadingNotice from '../components/loading-notice.jsx';
 import ProjectCardDetialed from '../components/project-card/project-card-detailed.jsx';
 import Service from '../js/service.js';
 import Utility from '../js/utility.js';
@@ -70,15 +71,6 @@ class Entry extends React.Component {
     });
   }
 
-  renderLoadingNotice() {
-    // 3 empty <div></div> here are for the loading animation dots (done in CSS) to show.
-    return <div className="loading my-5 d-flex justify-content-center align-items-center">
-              <div></div>
-              <div></div>
-              <div></div>
-            </div>;
-  }
-
   renderEntry() {
     if (!this.state.dataLoaded) return null;
 
@@ -104,7 +96,7 @@ class Entry extends React.Component {
   render() {
     return (
       <div className="row justify-content-center">
-        { !this.state.dataLoaded ? this.renderLoadingNotice() : this.renderEntry() }
+        { !this.state.dataLoaded ? <LoadingNotice /> : this.renderEntry() }
       </div>
     );
   }

--- a/pages/my-profile.jsx
+++ b/pages/my-profile.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { Link } from 'react-router';
+import ReactGA from 'react-ga';
+import NotFound from './not-found.jsx';
+import Service from '../js/service';
+import Profile from './profile.jsx';
+import LoadingNotice from '../components/loading-notice.jsx';
+import user from '../js/app-user';
+import utility from '../js/utility';
+
+class MyProfile extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      user,
+      userProfile: null,
+      showLoadingNotice: true
+    };
+  }
+
+  componentDidMount() {
+    user.addListener(this);
+    user.verify(this.props.router.location);
+  }
+
+  componentWillUnmount() {
+    user.removeListener(this);
+  }
+
+  updateUser(event) {
+    // this updateUser method is called by "user" after changes in the user state happened
+    if (event === `verified` ) {
+      this.setState({ user }, () => {
+        if (this.state.user.loggedin) {
+          this.fetchProfile(this.props.params.id, newState => {
+            this.setState(newState);
+          });
+        }
+      });
+    }
+  }
+
+  fetchProfile(profileId, response) {
+    Service.profileMe()
+    .then(userProfile => {
+      response({
+        userProfile,
+        showLoadingNotice: false
+      });
+    })
+    .catch(reason => {
+      console.error(reason);
+      response({
+        showLoadingNotice: false
+      });
+    });
+  }
+
+  handleSignInBtnClick(event) {
+    event.preventDefault();
+
+    ReactGA.event({
+      category: `Account`,
+      action: `Login`,
+      label: `Login ${window.location.pathname}`,
+      transport: `beacon`
+    });
+
+    user.login(utility.getCurrentURL());
+  }
+
+  renderProfile() {
+    if (!this.state.userProfile) return <NotFound header="Profile not found" />;
+
+    return <Profile profile={this.state.userProfile} />;
+  }
+
+  getContentForLoggedInUser() {
+    return this.state.showLoadingNotice ? <LoadingNotice /> : this.renderProfile();
+  }
+
+  getAnonymousContent() {
+    return <NotFound header="You do not have access to this page" linkComponent={null}>
+      <p><button className="btn btn-link inline-link" onClick={(event) => this.handleSignInBtnClick(event)}>Log in</button> or see <Link to="/featured">Featured projects</Link></p>
+    </NotFound>;
+  }
+
+  renderContent() {
+    if (user.loggedin === undefined) return null;
+
+    if (user.loggedin) return this.getContentForLoggedInUser();
+
+    return this.getAnonymousContent();
+  }
+
+  render() {
+    return this.renderContent();
+  }
+}
+
+export default MyProfile;

--- a/pages/my-profile.jsx
+++ b/pages/my-profile.jsx
@@ -80,7 +80,7 @@ class MyProfile extends React.Component {
   }
 
   getAnonymousContent() {
-    return <NotFound header="You do not have access to this page" linkComponent={null}>
+    return <NotFound header="You do not have access to this page" linkComponent={false}>
       <p><button className="btn btn-link inline-link" onClick={(event) => this.handleSignInBtnClick(event)}>Log in</button> or see <Link to="/featured">Featured projects</Link></p>
     </NotFound>;
   }

--- a/pages/not-found.jsx
+++ b/pages/not-found.jsx
@@ -1,16 +1,28 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import HintMessage from '../components/hint-message/hint-message.jsx';
 
-class NotFound extends React.Component {
-  render() {
-    return (
-      <HintMessage iconComponent={<img src="/assets/svg/icon-404.svg" />}
-                   header={`Something's wrong`}
-                   linkComponent={<Link to={`/featured`}>Explore featured</Link>}>
-        <p>Check your URL or try a search. Still no luck? <a href="https://github.com/mozilla/network-pulse/issues/new">Let us know</a>.</p>
-      </HintMessage>
-    );
-  }
-}
+const NotFound = (props) => {
+  return (
+    <HintMessage iconComponent={<img src="/assets/svg/icon-404.svg" />}
+                 header={props.header}
+                 linkComponent={props.linkComponent}>
+      { props.children }
+    </HintMessage>
+  );
+};
+
+NotFound.propTypes = {
+  header: PropTypes.string,
+  linkComponent: PropTypes.element,
+  children: PropTypes.element
+};
+
+NotFound.defaultProps = {
+  header: `Something's wrong`,
+  linkComponent: <Link to={`/featured`}>Explore featured</Link>,
+  children: <p>Check your URL or try a search. Still no luck? <a href="https://github.com/mozilla/network-pulse/issues/new">Let us know</a>.</p>
+};
+
 export default NotFound;

--- a/pages/not-found.jsx
+++ b/pages/not-found.jsx
@@ -15,7 +15,10 @@ const NotFound = (props) => {
 
 NotFound.propTypes = {
   header: PropTypes.string,
-  linkComponent: PropTypes.element,
+  linkComponent: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.bool,
+  ]),
   children: PropTypes.element
 };
 

--- a/pages/profile-edit/profile-edit.jsx
+++ b/pages/profile-edit/profile-edit.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { browserHistory } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import { Helmet } from "react-helmet";
 import { Form } from 'react-formbuilder';
-import HintMessage from '../../components/hint-message/hint-message.jsx';
+import NotFound from '../not-found.jsx';
 import utility from '../../js/utility';
 import user from '../../js/app-user';
 import fields from './form/fields';
@@ -89,24 +89,9 @@ export default React.createClass({
             </div>);
   },
   getAnonymousContent() {
-    let header = `Please sign in to edit your profile.`;
-    let linkComponent = <a href={user.getLoginURL(utility.getCurrentURL())}
-                           onClick={(event) => this.handleSignInBtnClick(event)}>
-                           Sign in with Google
-                        </a>;
-    let additionalMessage;
-
-    if (user.failedLogin) {
-      header = `Sign in failed`;
-      linkComponent = <Link to={`/featured`}>Explore featured</Link>;
-      additionalMessage = <p>Sorry, login failed! Please try again or <a href="mailto:https://mzl.la/pulse-contact">contact us</a>.</p>;
-    }
-
-    return <HintMessage iconComponent={<span className={`fa fa-user`}></span>}
-                         header={header}
-                         linkComponent={linkComponent}>
-              {additionalMessage}
-            </HintMessage>;
+    return <NotFound header="You do not have access to this page" linkComponent={false}>
+      <p><button className="btn btn-link inline-link" onClick={(event) => this.handleSignInBtnClick(event)}>Log in</button> or see <Link to="/featured">Featured projects</Link></p>
+    </NotFound>;
   },
   getContent() {
     if (user.loggedin === undefined) return null;

--- a/pages/public-profile.jsx
+++ b/pages/public-profile.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import NotFound from './not-found.jsx';
+import Service from '../js/service';
+import Profile from './profile.jsx';
+
+class PublicProfile extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      userProfile: null,
+      showLoadingNotice: true
+    };
+  }
+
+  componentDidMount() {
+    this.fetchProfile(this.props.params.id, newState => {
+      this.setState(newState);
+    });
+  }
+
+  fetchProfile(profileId, response) {
+    Service.profile(profileId)
+    .then(userProfile => {
+      response({
+        userProfile,
+        showLoadingNotice: true
+      });
+    })
+    .catch(reason => {
+      console.error(reason);
+      response({
+        showLoadingNotice: false
+      });
+    });
+  }
+
+  renderProfile() {
+    if (!this.state.userProfile) return <NotFound header="Profile not found" />;
+
+    return <Profile profile={this.state.userProfile} />;
+  }
+
+  renderLoadingNotice() {
+    // 3 empty <div></div> here are for the loading animation dots (done in CSS) to show.
+    return <div className="loading my-5 d-flex justify-content-center align-items-center">
+              <div></div>
+              <div></div>
+              <div></div>
+            </div>;
+  }
+
+  render() {
+    return this.state.showLoadingNotice ? this.renderLoadingNotice() : this.renderProfile();
+  }
+}
+
+export default PublicProfile;

--- a/pages/public-profile.jsx
+++ b/pages/public-profile.jsx
@@ -24,7 +24,7 @@ class PublicProfile extends React.Component {
     .then(userProfile => {
       response({
         userProfile,
-        showLoadingNotice: true
+        showLoadingNotice: false
       });
     })
     .catch(reason => {

--- a/pages/public-profile.jsx
+++ b/pages/public-profile.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import NotFound from './not-found.jsx';
 import Service from '../js/service';
 import Profile from './profile.jsx';
+import LoadingNotice from '../components/loading-notice.jsx';
 
 class PublicProfile extends React.Component {
   constructor(props) {
@@ -40,17 +41,8 @@ class PublicProfile extends React.Component {
     return <Profile profile={this.state.userProfile} />;
   }
 
-  renderLoadingNotice() {
-    // 3 empty <div></div> here are for the loading animation dots (done in CSS) to show.
-    return <div className="loading my-5 d-flex justify-content-center align-items-center">
-              <div></div>
-              <div></div>
-              <div></div>
-            </div>;
-  }
-
   render() {
-    return this.state.showLoadingNotice ? this.renderLoadingNotice() : this.renderProfile();
+    return this.state.showLoadingNotice ? <LoadingNotice /> : this.renderProfile();
   }
 }
 

--- a/routes.jsx
+++ b/routes.jsx
@@ -16,6 +16,7 @@ import Add from './pages/add/add.jsx';
 import Submitted from './pages/add/submitted.jsx';
 import Search from './pages/search/search.jsx';
 import Moderation from './pages/moderation.jsx';
+import PublicProfile from './pages/public-profile.jsx';
 import Profile from './pages/profile.jsx';
 import ProfileEdit from './pages/profile-edit/profile-edit.jsx';
 import NotFound from './pages/not-found.jsx';
@@ -68,29 +69,6 @@ class MyProfile extends React.Component {
 
   componentDidMount() {
     Service.profileMe()
-      .then(userProfile => {
-        this.setState({ userProfile });
-      })
-      .catch(reason => {
-        console.error(reason);
-      });
-  }
-
-  render() {
-    return <Profile profile={this.state.userProfile} />;
-  }
-}
-
-class PublicProfile extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      userProfile: null
-    };
-  }
-
-  componentDidMount() {
-    Service.profile(this.props.params.id)
       .then(userProfile => {
         this.setState({ userProfile });
       })

--- a/routes.jsx
+++ b/routes.jsx
@@ -17,6 +17,7 @@ import Submitted from './pages/add/submitted.jsx';
 import Search from './pages/search/search.jsx';
 import Moderation from './pages/moderation.jsx';
 import PublicProfile from './pages/public-profile.jsx';
+import MyProfile from './pages/my-profile.jsx';
 import Profile from './pages/profile.jsx';
 import ProfileEdit from './pages/profile-edit/profile-edit.jsx';
 import NotFound from './pages/not-found.jsx';
@@ -58,29 +59,6 @@ const Tag = (router) => {
   let searchParam = { key: `tag`, value: router.params.tag };
   return <SingleFilterCriteriaPage searchParam={searchParam} headerLabel="Tag" />;
 };
-
-class MyProfile extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      userProfile: null
-    };
-  }
-
-  componentDidMount() {
-    Service.profileMe()
-      .then(userProfile => {
-        this.setState({ userProfile });
-      })
-      .catch(reason => {
-        console.error(reason);
-      });
-  }
-
-  render() {
-    return <Profile profile={this.state.userProfile} />;
-  }
-}
 
 class App extends React.Component {
   constructor(props) {


### PR DESCRIPTION
Fixes [#685](https://github.com/mozilla/network-pulse/issues/685#issuecomment-327913388) .

### Things to check

**Public profile page (`/profile/<profileid>`)**
- [ ] go to a valid profile url and see if profile page gets rendered with bio and projects
- [ ] go to something like `/profile/12313131` or `/profile/hahahahahaha` and see if you get a 'profile not found' message

**My profile page(`/profile/me`)**
- [ ] logged in: see if profile page gets rendered with bio and projects
- [ ] not logged in: see if you get a notice asking you to log in

**Edit profile page**
- [ ] logged in: see if edit profile page gets rendered (as long as you see a form there we are good. The rest of the work to get the form functionalities in place is being reviewed in a different PR)
- [ ] not logged in: see if you get a notice asking you to log in

---

@gvn PR isn't very small, though the changes are not very complicated. Reviewing code commit by commit might make this PR easier to review.