### PR TITLE
blur the input on Enter

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "postcss-cli-simple": "^1.0.3",
     "prop-types": "^15.5.6",
     "react": "^15.4.1",
-    "react-debounce-input": "^2.4.2",
+    "react-debounce-input": "^3.1.0",
     "react-dom": "^15.4.1",
     "react-formbuilder": "^0.9.0",
     "react-ga": "^2.1.2",

--- a/pages/search/search.jsx
+++ b/pages/search/search.jsx
@@ -108,13 +108,28 @@ class Search extends React.Component {
                               value={this.state.keywordSearched}
                               debounceTimeout={300}
                               type="search"
-                              onChange={(event) => this.handleInputChange(event)}
+                              onChange={ event => this.handleInputChange(event) }
+                              inputRef={ ref => this.setDebounceInput(ref) }
                               placeholder="Search keywords, people, tags..."
                               className="form-control"
               />
               <button className="btn dismiss" onClick={() => this.handleDismissBtnClick()}>&times;</button>
             </div>
           </div>;
+  }
+
+  setDebounceInput(ref) {
+    if (this.debounceInputElement || !ref) {
+      return;
+    }
+    this.debounceInputElement = ref;
+    // Set up bindings so that when this input
+    // receives an "enter", we remove focus.
+    this.debounceInputElement.addEventListener(`keyup`, evt => {
+      if (evt.key === `Enter`) {
+        this.debounceInputElement.blur();
+      }
+    });
   }
 
   getModerationStates(input, callback) {


### PR DESCRIPTION
This uses an updated DebounceInput component, which as of v3 offers a direct link into the textfield that it uses so that we can blur it without needing to hack around it.

Fixes #492