### PR TITLE
Nav bar tweaks

### DIFF
--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -131,7 +131,7 @@ class NavBar extends React.Component {
               </IndexLink>
               { this.renderNavList() }
             </div>
-            <div className="pinned col-12 col-lg-3">
+            <div className="pinned col-6 col-lg-3">
               <ul className="list-unstyled d-flex justify-content-end align-items-center mb-0">
                 { this.renderName(`hidden-sm-down`) }
                 <NavListItem noMargin={true}><NavLink to="/add" className="btn-add d-inline-block"><span className="sr-only">Add</span></NavLink></NavListItem>

--- a/components/navbar/navbar.scss
+++ b/components/navbar/navbar.scss
@@ -14,7 +14,7 @@
 
 .navbar {
   display: block;
-  padding: 30px 0 0;
+  padding: 24px 0 0;
   border-radius: 0;
 
   .inner {
@@ -31,11 +31,18 @@
     background: rgba(0, 0, 0, 0.9);
     z-index: 1000000;
     padding: 1rem $grid-gutter-width-base/2;
+    overflow: auto;
 
     a {
       color: white;
       font-weight: 600;
       font-size: 26px;
+    }
+
+    a.active,
+    a.active > i.fa,
+    a:hover > i.fa {
+      text-decoration: underline;
     }
   }
 
@@ -70,11 +77,14 @@
     box-shadow: 2px 2px black;
     border: 2px solid black;
     cursor: pointer;
+    position: relative;
+    top: 3px;
+    transition: all 0.25s ease;
 
     &:hover,
     &:active,
     &:focus {
-      box-shadow: 6px 6px black;
+      box-shadow: 5px 5px black;
       transform: translate(-3px, -3px);
     }
 
@@ -87,7 +97,8 @@
   }
 
   hr {
-    margin-top: 34px;
+    margin-top: 25px;
+    margin-bottom: 25px;
   }
 
   @media screen and (min-width: $bp-md) {


### PR DESCRIPTION
Related to #731

### Addressed the following items on https://github.com/mozilla/network-pulse/issues/731#issuecomment-344330899

> - reduce height of the entire header (about from 220px to 180px)
> - make '+' icon hover state smooth like on Foundation site, rather than sudden jump
> - selected state for menu item should be underlined
> - link the little 'm' to the Feature page (like the full logo)

### Didn't get addressed

> - here's the logo in black pulse-logo.svg.zip

Not sure what this file is for. Might be for logo hover state? I checked a few Mozilla sites and none of them inverses logo colour on hover state. --- let's discuss this further in a followup ticket.

> Bug: (maybe open a new ticket for this?)
> If open the menu at a narrow screen width and then make it wide, the menu looks like this (seems ok on Foundation site):

This is probably not worth fixing as it is a rare case and there's probably no "clean" way of fixing it (without JS or duplicated DOM elements). 