### PR TITLE
GA changes

### DIFF
--- a/components/bio/bio.jsx
+++ b/components/bio/bio.jsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 class Bio extends React.Component {
   constructor(props) {
     super(props);
+    this.profileOwnerName = props.custom_name || props.name;
   }
 
   renderThumbnail() {
@@ -31,9 +32,7 @@ class Bio extends React.Component {
   }
 
   renderName() {
-    return <div className="name mr-sm-4 text-truncate mw-100">
-      {this.props.custom_name || this.props.name}
-    </div>;
+    return <div className="name mr-sm-4 text-truncate mw-100">{this.profileOwnerName}</div>;
   }
 
   renderSocialMedia() {
@@ -46,7 +45,7 @@ class Bio extends React.Component {
         "mr-sm-3" : i !== list.length-1
       });
 
-      return <a href={link} target="_blank" className={classname} key={type}><span className={`fa fa-${type}`}></span></a>;
+      return <a href={link} target="_blank" className={classname} onClick={(event) => this.handleSocialMediaClick(event, type)} key={type}><span className={`fa fa-${type}`}></span></a>;
     });
 
     return <div>{list}</div>;
@@ -56,6 +55,15 @@ class Bio extends React.Component {
     if (!this.props.my_profile) return null;
 
     return <div className="ml-sm-3"><button className="btn btn-link inline-link default-text-color-link" onClick={(event) => this.handleLogOutBtnClick(event)}>Sign out</button></div>;
+  }
+
+  handleSocialMediaClick(event, type) {
+    ReactGA.event({
+      category: `Profile`,
+      action: `Social link tap`,
+      label: `${this.profileOwnerName} - ${type}`,
+      transport: `beacon`
+    });
   }
 
   handleLogOutBtnClick(event) {

--- a/components/bio/bio.jsx
+++ b/components/bio/bio.jsx
@@ -85,7 +85,7 @@ class Bio extends React.Component {
     let meta = text;
 
     if (link) {
-      meta = <a href={link} className="default-text-color-link">{text}</a>;
+      meta = <a href={link} className="default-text-color-link" onClick={(event) => this.handleSocialMediaClick(event, type)}>{text}</a>;
     }
 
     return <div className={`meta-with-icon ${type} d-inline-block mr-4`}>{meta}</div>;

--- a/components/nav-link/nav-link.jsx
+++ b/components/nav-link/nav-link.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router';
-import ReactGA from 'react-ga';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
@@ -10,18 +9,9 @@ class NavLink extends React.Component {
   }
 
   handleClick() {
-    this.handleInternalPageLinkClick();
     if (this.props.onClick) {
       this.props.onClick();
     }
-  }
-
-  handleInternalPageLinkClick() {
-    ReactGA.event({
-      category: `Nav Link`,
-      action: `Clicked`,
-      label: this.props.to
-    });
   }
 
   render() {

--- a/components/project-card/meta/creators.jsx
+++ b/components/project-card/meta/creators.jsx
@@ -11,11 +11,12 @@ const Creators = (props) => {
 
   props.creators.forEach((creator)=>{
     // Link to creators with a profile, plain text name if without.
+    let name = creator.name;
     let url = null;
     if(typeof creator.profile_id === `number` && props.makeLink) {
       url = `/profile/${creator.profile_id}`;
     }
-    creators.push( <a key={creator.name} href={url}>{creator.name}</a> );
+    creators.push( <a key={name} href={url} onClick={(event) => props.creatorClickHandler(event, name)}>{name}</a> );
     creators.push( `, `);
   });
 
@@ -29,7 +30,8 @@ const Creators = (props) => {
 Creators.propTypes = {
   creators: PropTypes.arrayOf(PropTypes.object).isRequired,
   showLabelText: PropTypes.bool,
-  makeLink: PropTypes.bool
+  makeLink: PropTypes.bool,
+  creatorClickHandler: PropTypes.func.isRequired
 };
 
 Creators.defaultProps = {

--- a/components/project-card/meta/get-involved.jsx
+++ b/components/project-card/meta/get-involved.jsx
@@ -10,7 +10,10 @@ class GetInvolved extends React.Component {
   }
 
   handleGetInvolvedLinkClick() {
-    this.props.sendGaEvent(`Get involved link tap`, `beacon`);
+    this.props.sendGaEvent({
+      action: `Get involved link tap`,
+      transport: `beacon`
+    });
   }
 
   renderGetInvolvedText() {

--- a/components/project-card/project-card-detailed.jsx
+++ b/components/project-card/project-card-detailed.jsx
@@ -23,17 +23,15 @@ class DetailedProjectCard extends React.Component {
     };
   }
 
-  sendGaEvent(action = ``, transport = ``) {
-    let config = {
+  sendGaEvent(config) {
+    config = Object.assign({
       category: `Entry`,
-      action: action,
+      action: ``,
       label: this.props.title
-    };
+    }, config);
 
-    if (transport) {
-      config.transport = transport;
-    }
-
+    // config usually contains the following properties:
+    // category, action, label, transport
     ReactGA.event(config);
   }
 
@@ -62,12 +60,32 @@ class DetailedProjectCard extends React.Component {
     this.setState({ bookmarked: isBookmarked });
   }
 
+  handleCreatorClick(event, creator) {
+    this.sendGaEvent({
+      action: `Creator tap`,
+      label: `${this.props.title} - ${creator}`
+    });
+  }
+
+  handlePublisherClick(event, publisher) {
+    this.sendGaEvent({
+      action: `Submitter tap`,
+      label: `${this.props.title} - ${publisher}`
+    });
+  }
+
   handleTwitterShareClick() {
-    this.sendGaEvent(`Twitter share tap`, `beacon`);
+    this.sendGaEvent({
+      action: `Twitter share tap`,
+      transport: `beacon`
+    });
   }
 
   handleVisitBtnClick() {
-    this.sendGaEvent(`Visit button tap`, `beacon`);
+    this.sendGaEvent({
+      action: `Visit button tap`,
+      transport: `beacon`
+    });
   }
 
   renderVisitButton() {
@@ -80,7 +98,7 @@ class DetailedProjectCard extends React.Component {
     if (!this.props.created && !this.props.publishedBy) return null;
 
     let timePosted = this.props.created ? ` ${moment(this.props.created).format(`MMM DD, YYYY`)}` : null;
-    let publishedBy = this.props.publishedBy ? <span> by <Link to={`/profile/${this.props.submitterProfileId}`}>{this.props.publishedBy}</Link></span> : null;
+    let publishedBy = this.props.publishedBy ? <span> by <Link to={`/profile/${this.props.submitterProfileId}`} onClick={(event) => this.handlePublisherClick(event,this.props.publishedBy)}>{this.props.publishedBy}</Link></span> : null;
 
     return (
       <p><small className="time-posted d-block">
@@ -110,7 +128,11 @@ class DetailedProjectCard extends React.Component {
             <div className="row">
               <div className="col-12 col-sm-8">
                 <Title title={this.props.title} className="mb-1" />
-                <Creators creators={this.props.relatedCreators} showLabelText={true} />
+                <Creators
+                  creators={this.props.relatedCreators}
+                  showLabelText={true}
+                  creatorClickHandler={(event, name) => this.handleCreatorClick(event, name)}
+                />
               </div>
             </div>
           </div>;
@@ -137,7 +159,7 @@ class DetailedProjectCard extends React.Component {
               <GetInvolved getInvolved={this.props.getInvolved}
                            getInvolvedUrl={this.props.getInvolvedUrl}
                            helpTypes={this.props.helpTypes}
-                           sendGaEvent={(action, transport) => this.sendGaEvent(action, transport)} />
+                           sendGaEvent={(config) => this.sendGaEvent(config)} />
             </div>;
   }
 

--- a/components/project-card/project-card-simple.jsx
+++ b/components/project-card/project-card-simple.jsx
@@ -22,19 +22,18 @@ class ProjectCard extends React.Component {
     };
   }
 
-  sendGaEvent(action = ``, transport = ``) {
-    let config = {
+  sendGaEvent(config) {
+    config = Object.assign({
       category: `Entry`,
-      action: action,
+      action: ``,
       label: this.props.title
-    };
+    }, config);
 
-    if (transport) {
-      config.transport = transport;
-    }
-
+    // config usually contains the following properties:
+    // category, action, label, transport
     ReactGA.event(config);
   }
+
 
   componentDidMount() {
     this.setInitialBookmarkedStatus();
@@ -61,8 +60,17 @@ class ProjectCard extends React.Component {
     this.setState({ bookmarked: isBookmarked });
   }
 
+  handleCreatorClick(event, creator) {
+    this.sendGaEvent({
+      action: `Creator tap`,
+      label: `${this.props.title} - ${creator}`
+    });
+  }
+
   handleReadMoreClick() {
-    this.sendGaEvent(`Read More`);
+    this.sendGaEvent({
+      action: `Read More`,
+    });
   }
 
   renderActionPanel() {
@@ -93,7 +101,7 @@ class ProjectCard extends React.Component {
               <GetInvolved getInvolved={this.props.getInvolved}
                            getInvolvedUrl={this.props.getInvolvedUrl}
                            helpTypes={this.props.helpTypes}
-                           sendGaEvent={(action, transport) => this.sendGaEvent(action, transport)} />
+                           sendGaEvent={(config) => this.sendGaEvent(config)} />
           </div>;
   }
 
@@ -104,7 +112,7 @@ class ProjectCard extends React.Component {
       { label: `Link`, link: this.props.contentUrl },
       { label: `Help`, link: this.props.getInvolvedUrl }
     ].map(url => {
-      return url.link && <li>{url.label}: <a href={url.link} target="_blank">{url.link}</a></li>;
+      return url.link && <li key={url.label}>{url.label}: <a href={url.link} target="_blank">{url.link}</a></li>;
     });
 
     return <ul className="list-unstyled">{urls}</ul>;
@@ -138,7 +146,10 @@ class ProjectCard extends React.Component {
                 />
                 { this.renderActionPanel() }
               </div>
-              <Creators creators={this.props.relatedCreators} />
+              <Creators
+                creators={this.props.relatedCreators}
+                creatorClickHandler={(event, name) => this.handleCreatorClick(event, name)}
+              />
               { this.props.onModerationMode && <Description description={this.props.description} /> }
               { this.renderExtraMeta() }
               { this.renderFullUrlSection() }

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -17,7 +17,7 @@ export default {
 
     if (_dntStatus !== `Enabled`){
       // if user doesn't have Do Not Track turned on, initialize GA script
-      ReactGA.initialize(`UA-87658599-4`);
+      ReactGA.initialize(`UA-87658599-4`, {debug: true});
     }
   },
   logPageView: function() {

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -17,7 +17,7 @@ export default {
 
     if (_dntStatus !== `Enabled`){
       // if user doesn't have Do Not Track turned on, initialize GA script
-      ReactGA.initialize(`UA-87658599-4`, {debug: true});
+      ReactGA.initialize(`UA-87658599-4`);
     }
   },
   logPageView: function() {


### PR DESCRIPTION
Related to #746 #844 

To test locally
1. go to `js/analytics.js` and add `{debug: true}` as the 2nd parameter to line 20.
i.e., ```ReactGA.initialize(`UA-87658599-4`, {debug: true});```
2. open console on your browser dev tool
3. look for "react-ga" logs and use below as checklist



## 🔵 Clicking on any item on nav bar does NOT trigger an GA event
e.g., this should NOT happen <img width="832" alt="screen shot 2017-11-20 at 5 31 30 pm" src="https://user-images.githubusercontent.com/2896608/33050258-c29ac1f2-ce18-11e7-999b-38d017831dae.png">

## 🔵  Profile page - clicking on social media icons and "website" link triggers an GA event
`eventLabel` should be `[name of profile owner] - type of social media icon you clicked`
e.g., <img width="1050" alt="screen shot 2017-11-20 at 5 40 38 pm" src="https://user-images.githubusercontent.com/2896608/33050490-f598ae06-ce19-11e7-94f1-dac0b66c840d.png">
<img width="1057" alt="screen shot 2017-11-21 at 2 41 52 pm" src="https://user-images.githubusercontent.com/2896608/33100723-4faeb0e2-ceca-11e7-89ab-e56749d91015.png">



## 🔵  Entry - clicking on project creator name triggers an GA event
`eventLabel` should be `[name of project] - [name of creator you clicked]`
e.g., <img width="1004" alt="screen shot 2017-11-20 at 5 36 33 pm" src="https://user-images.githubusercontent.com/2896608/33050406-a8352f22-ce19-11e7-9e5e-7679a7c06bf8.png">


## 🔵  Entry - clicking on the person who submitted/published the entry triggers an GA event
`eventLabel` should be `[name of entry] -  [name of the entry submitter/publisher you clicked]`
e.g., <img width="1014" alt="screen shot 2017-11-20 at 5 42 23 pm" src="https://user-images.githubusercontent.com/2896608/33050540-353c1354-ce1a-11e7-9d2e-0a60071652b5.png">



