### PR TITLE
Form error styling tweaks

### DIFF
--- a/pages/add/add.scss
+++ b/pages/add/add.scss
@@ -5,7 +5,7 @@
 
   fieldset.title {
     .error {
-      margin-right: 50px;
+      margin-right: 3rem;
     }
   }
 

--- a/pages/add/add.scss
+++ b/pages/add/add.scss
@@ -3,6 +3,12 @@
     margin-top: $form-field-vertical-margin / 2;
   }
 
+  fieldset.title {
+    .error {
+      margin-right: 50px;
+    }
+  }
+
   fieldset.published_by_creator {
     input {
       margin-right: $form-check-input-margin-x;

--- a/pages/add/form/basic-info-fields.js
+++ b/pages/add/form/basic-info-fields.js
@@ -13,8 +13,7 @@ module.exports = {
     ],
     charLimit: 80,
     charLimitText: function(charCount, charLimit) {
-      // show a twitter-style "characters remainig" count
-      return charLimit - charCount;
+      return `${charCount}/${charLimit}`;
     }
   },
   'content_url': { // required field

--- a/pages/add/form/basic-info-fields.js
+++ b/pages/add/form/basic-info-fields.js
@@ -13,7 +13,8 @@ module.exports = {
     ],
     charLimit: 80,
     charLimitText: function(charCount, charLimit) {
-      return `${charCount}/${charLimit}`;
+      // show a twitter-style "characters remainig" count
+      return charLimit - charCount;
     }
   },
   'content_url': { // required field

--- a/scss/form.scss
+++ b/scss/form.scss
@@ -1,6 +1,11 @@
 // most of the following CSS rules are to style form elements created by the "react-formbuilder" library
 
 .inline.error {
+  color: $form-error-color;
+  font-style: italic;
+  font-size: 0.875rem;
+  margin-top: 5px;
+
   &::before {
     font-family: "FontAwesome";
     content: "\f00d";
@@ -52,10 +57,11 @@ p.guide-text {
 }
 
 span.char-limit {
-  text-align: right;
-  width: 100%;
-  display: inline-block;
+  position: absolute;
+  right: $grid-gutter-width-base/2;
   color: $form-text-light;
+  font-size: 0.875rem;
+  padding-top: 5px;
 }
 
 .over-char-limit {

--- a/scss/form.scss
+++ b/scss/form.scss
@@ -1,5 +1,24 @@
 // most of the following CSS rules are to style form elements created by the "react-formbuilder" library
 
+.inline.error {
+  &::before {
+    font-family: "FontAwesome";
+    content: "\f00d";
+    display: inline-block;
+    margin-right: 0.4rem;
+    font-style: normal;
+  }
+}
+
+.error.form-control {
+  border-color: $form-error-color;
+
+  + .char-limit,
+  + .word-limit {
+    color: $form-error-color;
+  }
+}
+
 .checkboxGroup {
   label {
     @extend .form-check-label;

--- a/scss/form.scss
+++ b/scss/form.scss
@@ -1,10 +1,13 @@
+$field-hint-top-spacing: 5px;
+$field-hint-font-size: 0.875rem;
+
 // most of the following CSS rules are to style form elements created by the "react-formbuilder" library
 
 .inline.error {
   color: $form-error-color;
   font-style: italic;
-  font-size: 0.875rem;
-  margin-top: 5px;
+  font-size: $field-hint-font-size;
+  margin-top: $field-hint-top-spacing;
 
   &::before {
     font-family: "FontAwesome";
@@ -60,8 +63,8 @@ span.char-limit {
   position: absolute;
   right: $grid-gutter-width-base/2;
   color: $form-text-light;
-  font-size: 0.875rem;
-  padding-top: 5px;
+  font-size: $field-hint-font-size;
+  padding-top: $field-hint-top-spacing;
 }
 
 .over-char-limit {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -110,13 +110,6 @@ hr.hr-gradient {
 
 form {
   font-family: inherit;
-
-  .inline.error {
-    color: $form-error-color;
-    font-style: italic;
-    font-size: 0.875rem;
-    margin-top: 5px;
-  }
 }
 
 label {


### PR DESCRIPTION
Related to #806 

---

@kristinashu 

<img width="754" alt="screen shot 2017-11-17 at 4 44 33 pm" src="https://user-images.githubusercontent.com/2896608/32974886-ef5fab3a-cbb6-11e7-83b1-eda4a5e439dc.png">

We can't smartly and easily position error message and character counter on the same line because each of them belongs to a different parent element (green box and blue box). Do you think removing "x This field cannot be left blank" and just showing a red "0/80" is enough?