### PR TITLE
Remove extra divider on mobile

### DIFF
--- a/components/project-card/project-card-detailed.jsx
+++ b/components/project-card/project-card-detailed.jsx
@@ -157,7 +157,7 @@ class DetailedProjectCard extends React.Component {
         </div>
         <div className="row">
           <div className="col-12 col-md-8">
-            <p className="report-correction mt-3 pt-3"><small>Correction? <a href="https://mzl.la/pulse-contact">Contact us</a>.</small></p>
+            <p className="report-correction mt-md-3 pt-md-3"><small>Correction? <a href="https://mzl.la/pulse-contact">Contact us</a>.</small></p>
           </div>
         </div>
       </div>

--- a/components/project-card/project-card.scss
+++ b/components/project-card/project-card.scss
@@ -38,10 +38,6 @@
     border-bottom: 1px solid $gray-lighter;
   }
 
-  &.detail-view .report-correction {
-    border-top: 1px solid $gray-lighter;
-  }
-
   .share {
     .btn {
       width: 20px;
@@ -101,6 +97,12 @@
 
   .moderation-panel {
     background: $gray-lightest;
+  }
+
+  @media screen and (min-width: $bp-md) {
+    &.detail-view .report-correction {
+      border-top: 1px solid $gray-lighter;
+    }
   }
 }
 


### PR DESCRIPTION
Related to #790 

Tiny PR... to test, just to go detailed view for any entry and see if you still get 2 divider lines before the "correction?" link on mobile.