### PR TITLE
Bumped up Pulse's Observatory score

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -1,0 +1,37 @@
+{
+  "name": "Mozilla Network Pulse",
+  "description": "A platform for discovering and collaborating on projects for a healthy internet.",
+  "repository": {
+    "url": "https://github.com/mozilla/network-pulse",
+    "license": "MPL2",
+    "tests": "https://travis-ci.org/mozilla/network-pulse"
+  },
+  "participate": {
+    "home": "https://github.com/mozilla/network-pulse",
+    "docs": "https://github.com/mozilla/network-pulse",
+    "irc": "irc://irc.mozilla.org/#foundation",
+    "irc-contacts": [
+      "cade",
+      "alanmoo",
+      "mattheww",
+      "Pomax",
+      "mavis"
+    ]
+  },
+  "bugs": {
+    "list": "https://github.com/mozilla/network-pulse/issues",
+    "report": "https://github.com/mozilla/network-pulse/issues/new"
+  },
+  "urls": {
+    "prod": "network-pulse-staging.herokuapp.com",
+    "staging": "network-pulse-staging.herokuapp.com"
+  },
+  "keywords": [
+    "JavaScript",
+    "HTML",
+    "NodeJS",
+    "CSS",
+    "Sass",
+    "ReactJS"
+  ]
+}

--- a/contribute.json
+++ b/contribute.json
@@ -23,8 +23,8 @@
     "report": "https://github.com/mozilla/network-pulse/issues/new"
   },
   "urls": {
-    "prod": "network-pulse-staging.herokuapp.com",
-    "staging": "network-pulse-staging.herokuapp.com"
+    "prod": "https://www.mozillapulse.org",
+    "staging": "https://network-pulse-staging.herokuapp.com"
   },
   "keywords": [
     "JavaScript",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bootstrap:prefix": "postcss --use autoprefixer -o dist/css/mofo-bootstrap.css dist/css/mofo-bootstrap.css",
     "copy:index": "shx cp index.html dist/index.html",
     "copy:manifest": "shx cp manifest.json dist",
+    "copy:contributejson": "shx cp contribute.json dist",
     "copy:assets": "shx cp favicon.png dist && shx cp -r assets dist",
     "server": "node dist/server.bundle.js",
     "snyk-protect": "snyk protect",

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ app.use(helmet.xssFilter({
 // maxAge for HSTS header must be at least 6 months
 // (see https://wiki.mozilla.org/Security/Guidelines/Web_Security#HTTP_Strict_Transport_Security)
 app.use(helmet.hsts({
-  maxAge: 15768000, // 6 months in seconds
+  maxAge: 15768000*2, // 12 months in seconds
   setIf: (req, res) => {
     if (req.headers['x-forwarded-proto'] && req.headers['x-forwarded-proto'] === "https") {
       return true;

--- a/server.js
+++ b/server.js
@@ -32,9 +32,10 @@ app.use(helmet.xssFilter({
   setOnOldIE: true
 }));
 
-// maxAge for HSTS header must be at least 18 weeks (see https://hstspreload.org/)
+// maxAge for HSTS header must be at least 6 months
+// (see https://wiki.mozilla.org/Security/Guidelines/Web_Security#HTTP_Strict_Transport_Security)
 app.use(helmet.hsts({
-  maxAge: 60 * 60 * 24 * 7 * 18, // 18 weeks in seconds
+  maxAge: 15768000, // 6 months in seconds
   setIf: (req, res) => {
     if (req.headers['x-forwarded-proto'] && req.headers['x-forwarded-proto'] === "https") {
       return true;


### PR DESCRIPTION
Related to #875 

Not sure what to do with the SRI part. I couldn't generate integrity for [`https://platform.twitter.com/widgets.js`](https://github.com/mozilla/network-pulse/blob/master/server.js#L94) using [SRI Hash Generator](https://www.srihash.org/)

> Error: this resource is not eligible for integrity checks. See http://enable-cors.org/server.html