### PR TITLE
Better /issues routes handling

### DIFF
--- a/main.jsx
+++ b/main.jsx
@@ -68,7 +68,7 @@ const Routes = () => (
       <Route exact path="/issues" component={Issues} />
       <Route path="/issues/:issue" component={Issue} />
       <Route path="/entry/:entryId" component={Entry} />
-      <Route path="/add" component={Add} onEnter={() => { if (typeof window !== `undefined`) { window.scroll(0, 0); } }} />
+      <Route path="/add" component={Add} />
       <Route path="/submitted" component={Submitted} />
       <Route path="/search" component={Search} />
       <Route exact path="/tags" render={() => <Redirect to="/latest"/>} />
@@ -116,14 +116,4 @@ class Main extends React.Component {
   }
 }
 
-
-// We have renamed all non user facing "favorites" related variables and text (e.g., favs, faved, etc) to "bookmarks".
-// This is because we want client side code to match what Pulse API uses (i.e., bookmarks)
-// For user facing bits like UI labels and URL path we want them to stay as "favorites".
-// That's why a route like <Route path="favs" component={Bookmarks} /> is seen here.
-// For more info see: https://github.com/mozilla/network-pulse/issues/326
-
-// PageSettings is used to preserve a project list view state.
-// Attach route enter hook pageSettings.setCurrentPathname(evt.location.pathname)
-// *only* to routes that render a list of projects.
 export default Main;

--- a/main.jsx
+++ b/main.jsx
@@ -68,7 +68,7 @@ const Routes = () => (
       <Route exact path="/issues" component={Issues} />
       <Route path="/issues/:issue" component={Issue} />
       <Route path="/entry/:entryId" component={Entry} />
-      <Route path="/add" component={Add} />
+      <Route path="/add" component={Add} onEnter={() => { if (typeof window !== `undefined`) { window.scroll(0, 0); } }} />
       <Route path="/submitted" component={Submitted} />
       <Route path="/search" component={Search} />
       <Route exact path="/tags" render={() => <Redirect to="/latest"/>} />

--- a/main.jsx
+++ b/main.jsx
@@ -68,7 +68,7 @@ const Routes = () => (
       <Route exact path="/issues" component={Issues} />
       <Route path="/issues/:issue" component={Issue} />
       <Route path="/entry/:entryId" component={Entry} />
-      <Route path="/add" component={Add} onEnter={() => { if (typeof window !== `undefined`) { window.scroll(0, 0); } }} />
+      <Route path="/add" component={Add} />
       <Route path="/submitted" component={Submitted} />
       <Route path="/search" component={Search} />
       <Route exact path="/tags" render={() => <Redirect to="/latest"/>} />

--- a/pages/issue.jsx
+++ b/pages/issue.jsx
@@ -6,7 +6,7 @@ import ProjectLoader from '../components/project-loader/project-loader.jsx';
 import Utility from '../js/utility.js';
 
 export default function (props) {
-  const issueParam = props.match.params.issue;
+  const issueParam = decodeURIComponent(props.match.params.issue);
   let issueName = Utility.getIssueNameFromUriPath(issueParam);
 
   // render page if issueName is one of the 5 hyphenated all lowercase routes we want to serve

--- a/pages/issue.jsx
+++ b/pages/issue.jsx
@@ -1,15 +1,32 @@
 import React from 'react';
+import { Redirect } from 'react-router-dom';
 import { Helmet } from "react-helmet";
 import IssueSelector from '../components/issue-selector/issue-selector.jsx';
 import ProjectLoader from '../components/project-loader/project-loader.jsx';
 import Utility from '../js/utility.js';
 
 export default function (props) {
-  const issueName = Utility.getIssueNameFromUriPath(props.match.params.issue);
+  const issueParam = props.match.params.issue;
+  let issueName = Utility.getIssueNameFromUriPath(issueParam);
 
-  return <div>
-            <Helmet><title>{issueName}</title></Helmet>
-            <IssueSelector />
-            <ProjectLoader issue={issueName} showCounter={true} />
-          </div>;
+  // render page if issueName is one of the 5 hyphenated all lowercase routes we want to serve
+  // e.g., digital-inclusion, open-innovation
+  if (issueName) {
+    return <div>
+              <Helmet><title>{issueName}</title></Helmet>
+              <IssueSelector />
+              <ProjectLoader issue={issueName} showCounter={true} />
+            </div>;
+  }
+
+  issueName = Utility.getUriPathFromIssueName(issueParam);
+
+  // redirect to the corresponding matching route if issueName is a known "issue"
+  // e.g., "Digital Inclusion", "Open Innovation"
+  if (issueName) {
+    return <Redirect to={`/issues/${issueName}`} />;
+  }
+
+  // issueName can't be recognized, redirect to /issues
+  return <Redirect to="/issues" />;
 }


### PR DESCRIPTION
Related to #852 

Only these 5 child routes on `/issues/` are supported
- `/issues/online-privacy-and-security`
- `/issues/open-innovation`
- `/issues/decentralization`
- `/issues/web-literacy`
- `/issues/digital-inclusion`

Child route that includes the encoded issue name (e.g., `/issues/Open%20Innovation` should be redirected to the corresponding supported route `/issues/open-innovation`)

Any other child routes on `/issues/` will be redirected to `/issues` page.