### PR TITLE
removed double encoding, fixes help routes; Fixes #899

### DIFF
--- a/main.jsx
+++ b/main.jsx
@@ -50,12 +50,12 @@ const Latest = () => {
 };
 
 const Help = (router) => {
-  let searchParam = { key: `help_type`, value: router.match.params.helpType };
+  let searchParam = { key: `help_type`, value: decodeURIComponent(router.match.params.helpType) };
   return <SingleFilterCriteriaPage searchParam={searchParam} headerLabel="Help" />;
 };
 
 const Tag = (router) => {
-  let searchParam = { key: `tag`, value: router.match.params.tag };
+  let searchParam = { key: `tag`, value: decodeURIComponent(router.match.params.tag) };
   return <SingleFilterCriteriaPage searchParam={searchParam} headerLabel="Tag" />;
 };
 

--- a/pages/single-filter-criteria-page.jsx
+++ b/pages/single-filter-criteria-page.jsx
@@ -17,7 +17,7 @@ class SingleFilterCriteriaPage extends React.Component {
 
     return <div>
       <Helmet><title>{searchParam.value}</title></Helmet>
-      <h2>{`${this.props.headerLabel}: ${decodeURIComponent(searchParam.value)} `}</h2>
+      <h2>{`${this.props.headerLabel}: ${searchParam.value} `}</h2>
       <ProjectLoader {...params} showCounter={true} />
     </div>;
   }


### PR DESCRIPTION
Related issue: #899 
Summary: As suggested by @mmmavis at #899, the router match params were being encoded twice, and thus now thety are decoded once before setting it in `SingleFIleCriteriaPage`. 

Also, since they are already decoded now, they aren't further decoded in the `pages/single-filter-criteria-page.jsx` file.

@mmmavis Please review 