### PR TITLE
Social media Icon sizes have been increased to 40px

### DIFF
--- a/components/bio/bio.jsx
+++ b/components/bio/bio.jsx
@@ -42,7 +42,7 @@ class Bio extends React.Component {
       let link = this.props[type];
       if (!link) { return; }
 
-      let classname = classNames(`d-inline-block social-media px-2 px-sm-0`, {
+      let classname = classNames(`d-inline-block social-media`, {
         "mr-sm-3" : i !== list.length-1
       });
 

--- a/components/bio/bio.scss
+++ b/components/bio/bio.scss
@@ -13,6 +13,16 @@
     }
   }
 
+  .social-media {
+    width: 40px;
+    text-align: center;
+
+    @media screen and (min-width: $bp-md) {
+      width: auto;
+      text-align: left;
+    }
+  }
+
   .name {
     font-size: 1.75rem;
     font-weight: 500;


### PR DESCRIPTION
Related issue: #805 
Summary : @mmmavis , I have made the changes and as the icons were `font-awesome` icons so I only increased their `font-size` to `40px`.
Here is a screenshot of the changes made
![screenshot from 2018-01-12 18-00-24](https://user-images.githubusercontent.com/30361728/34875414-25ead61a-f7c3-11e7-874b-5923f48b7776.png)
 
and for desktop view
![screenshot from 2018-01-12 18-00-47](https://user-images.githubusercontent.com/30361728/34875486-6d8885a8-f7c3-11e7-9211-453990d1f1f3.png)
