### PR TITLE
Show character counts on fields that have character limit

### DIFF
--- a/pages/add/form/basic-info-fields.js
+++ b/pages/add/form/basic-info-fields.js
@@ -33,6 +33,10 @@ module.exports = {
     label: `Description: Simple, brief language works best. No jargon.`,
     placeholder: `Description`,
     fieldClassname: `form-control`,
-    validator: validator.maxLengthValidator(600)
+    validator: validator.maxLengthValidator(600),
+    charLimit: 600,
+    charLimitText: function (charCount, charLimit) {
+      return charLimit - charCount;
+    }
   },
 };

--- a/pages/profile-edit/form/fields.js
+++ b/pages/profile-edit/form/fields.js
@@ -25,7 +25,11 @@ module.exports = {
     fieldClassname: `form-control`,
     validator: [
       validator.maxLengthValidator(140)
-    ]
+    ],
+    charLimit: 140,
+    charLimitText: function (charCount, charLimit) {
+      return charLimit - charCount;
+    }
   },
   "twitter": {
     type: `text`,


### PR DESCRIPTION
Related issue: #770
Summary: There already exists a character count for the `Title` field. Thus I have used the same thing for `Bio` and `Description` fields
GIF:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/30361728/35255369-b3757054-0014-11e8-80a1-029f89f0b33f.gif)

@xmatthewx, please review.
