### PR TITLE
Clean help urls : Fixes #910

### DIFF
--- a/components/project-card/meta/get-involved.jsx
+++ b/components/project-card/meta/get-involved.jsx
@@ -20,7 +20,6 @@ class GetInvolved extends React.Component {
     let props = this.props;
     let getInvolvedText = props.getInvolved ? props.getInvolved : null;
     let getInvolvedLink = props.getInvolvedUrl ? ( <a href={props.getInvolvedUrl} target="_blank" onClick={() => this.handleGetInvolvedLinkClick()}>Get Involved</a>) : null;
-
     if (!getInvolvedText && !getInvolvedLink) return <p>{DEFAULT_TEXT}</p>;
 
     return <p>{getInvolvedText} {getInvolvedLink}</p>;
@@ -30,7 +29,7 @@ class GetInvolved extends React.Component {
     if (!this.props.helpTypes) return null;
 
     return this.props.helpTypes.map(helpType => {
-      return <Link to={`/help/${encodeURIComponent(helpType)}`} className="btn btn-xs btn-tag" key={helpType}>{helpType}</Link>;
+      return <Link to={`/help/${helpType.split(` `).join(`-`).split(`&`).join(`and`)}`} className="btn btn-xs btn-tag" key={helpType}>{helpType}</Link>;
     });
   }
 

--- a/js/service.js
+++ b/js/service.js
@@ -51,8 +51,10 @@ function getDataFromURL(route, params = {}, token = {}) {
   };
 
   Object.assign(params, defaultParams);
-
   return new Promise((resolve, reject) => {
+    if(params.help_type) {
+      params.help_type = params.help_type.split(`-`).join(` `).split(` and `).join(` & `);
+    }
     request.open(`GET`, `${route}${params ? toQueryString(params) : ``}`, true);
 
     request.withCredentials = true;
@@ -97,7 +99,6 @@ function getDataFromURL(route, params = {}, token = {}) {
  */
 function callURL(route) {
   let request = new XMLHttpRequest();
-
   return new Promise((resolve, reject) => {
     request.open(`GET`, route, true);
 


### PR DESCRIPTION
Related issue: #910 
Summary: As suggested by @alanmoo and @xmatthewx , the required changes have been made and they reflect too in the following preview. Refer #910 for more details about the same.

![cleanhelpurls](https://user-images.githubusercontent.com/25258877/35357711-60853c1e-017a-11e8-9665-c02800afeded.gif)

Please preview @alanmoo and @xmatthewx  :smile: 
