### PR TITLE
Set default value for a required prop 'entryCount'

### DIFF
--- a/components/profile-tab-group/profile-tab-group.jsx
+++ b/components/profile-tab-group/profile-tab-group.jsx
@@ -123,5 +123,8 @@ ProfileTabGroup.propTypes = {
   activeTab: PropTypes.string
 };
 
+ProfileTabGroup.defaultProps = {
+  entryCount: {}
+};
 
 export default ProfileTabGroup;


### PR DESCRIPTION
Just did a prod push and I started getting this error when visiting some profiles. I assumed every profile returned from API call would have this `entry_count` property... I guess I was wrong!

<img width="640" alt="screen shot 2018-06-07 at 12 00 01 pm" src="https://user-images.githubusercontent.com/2896608/41120434-58f0b954-6a4a-11e8-9dfe-7868ab732c50.png">
