### PR TITLE
Showed newest created project first on Profile Favs tab

### DIFF
--- a/components/profile-project-tab/profile-project-tab.jsx
+++ b/components/profile-project-tab/profile-project-tab.jsx
@@ -37,6 +37,10 @@ class ProfileProjectTab extends React.Component {
 
     this.props.projectTypes.forEach(type => {
       params[type] = true;
+
+      if (type === `favorited`) {
+        params.favorited_ordering = `-id`;
+      }
     });
 
     Service.profileEntries(this.state.profileId, params)


### PR DESCRIPTION
Related to #959

First project listed on that favs tab should have the largest `id`. You can verify by hovering over the project card and check the url shown in browser.

In the following screencap, the first project has id `373`

<img width="566" alt="screen shot 2018-07-13 at 11 57 58 am" src="https://user-images.githubusercontent.com/2896608/42709059-0ad220c6-8694-11e8-885a-ac4de36580f8.png">
