### PR TITLE
Update auth routes to use new api auth system

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ This starts a few image optimization scripts.
 ------------------|---------------------------------------------
 `PORT` | Default: `process.env.PORT`(falls back to `3000` if `process.env.PORT` cannot be found)<br><br>The port number you are running the server on.
 `PULSE_API` | Default: `https://pulse-api.mofostaging.net/api/pulse`<br><br>URL to Pulse API. e.g., `http://test.example.com:8000/api/pulse`. <br>To set up a local instance of Pulse API, follow instructions on [Pulse API README doc](https://github.com/mozilla/network-pulse-api/blob/master/README.md).
+`PULSE_LOGIN_URL` | Default: `https://pulse-api.mofostaging.net/accounts/login/`<br><br>URL to use to login to Pulse. This needs to be a Pulse API login url.
+`PULSE_LOGOUT_URL` | Default: `https://pulse-api.mofostaging.net/accounts/logout/`<br><br>URL to use to logout of Pulse. This needs to be a Pulse API logout url.
 `PROJECT_BATCH_SIZE`| Default: `24`<br><br>Number of projects you want to display as a batch. Make sure this number is divisible by 2 AND 3 so rows display evenly for different screen sizes.
 `LEARN_MORE_LINK` | Default: `https://www.mozillapulse.org/entry/120`<br><br>Link to learn more about what Pulse project is about.
 `NODE_ENV` | Default: `development`<br><br>When this is set to `production`, it enables production specific express settings and middleware

--- a/config/default.env
+++ b/config/default.env
@@ -1,5 +1,7 @@
 PORT=3000
 PULSE_API=https://pulse-api.mofostaging.net/api/pulse
+PULSE_LOGIN_URL=https://pulse-api.mofostaging.net/accounts/login/
+PULSE_LOGOUT_URL=https://pulse-api.mofostaging.net/accounts/logout/
 PROJECT_BATCH_SIZE=24
 LEARN_MORE_LINK=https://www.mozillapulse.org/entry/120
 APP_HOST=localhost

--- a/js/app-user.js
+++ b/js/app-user.js
@@ -3,6 +3,8 @@ import env from './env-client';
 import localstorage from './localstorage.js';
 import Service from './service.js';
 
+const loginUrl = env.PULSE_LOGIN_URL;
+
 /**
  * A set of helper functions for fascilitating login and logout
  * for users. This object should never be used directly, it should
@@ -13,7 +15,7 @@ const Login = {
    * Generates the oauth url for logging a user in, with a redirect-when-finished URL
    */
   getLoginURL(redirectUrl) {
-    return `${env.PULSE_API}/login?original_url=${encodeURIComponent(redirectUrl)}`;
+    return `${loginUrl}?next=${encodeURIComponent(redirectUrl)}`;
   },
 
   /*
@@ -133,6 +135,7 @@ class User {
     this.notifyListeners(`logged out`);
 
     Login.logout(error => {
+      alert(`Sorry, we encountered an error while logging you out!`);
       console.log(`logout error:`, error);
     });
   }

--- a/js/env-server.js
+++ b/js/env-server.js
@@ -19,7 +19,9 @@ let envUtilities= {
       PORT: process.env.PORT,
       LEARN_MORE_LINK: process.env.LEARN_MORE_LINK,
       PROJECT_BATCH_SIZE: process.env.PROJECT_BATCH_SIZE,
-      PULSE_API: `${process.env.PULSE_API}/v2`
+      PULSE_API: `${process.env.PULSE_API}/v2`,
+      PULSE_LOGIN_URL: process.env.PULSE_LOGIN_URL,
+      PULSE_LOGOUT_URL: process.env.PULSE_LOGOUT_URL
     };
 
     return JSON.stringify(config);

--- a/js/service.js
+++ b/js/service.js
@@ -1,6 +1,7 @@
 import env from './env-client';
 
 let pulseAPI = env.PULSE_API;
+let pulseAPILogout = env.PULSE_LOGOUT_URL;
 
 /*
  * A helper function to process value in a key-value pair into a valid query param value
@@ -243,7 +244,7 @@ let Service = {
     }
   },
   logout: function() {
-    return callURL(`${pulseAPI}/logout/`);
+    return callURL(pulseAPILogout);
   },
   userstatus: function() {
     return getDataFromURL(`${pulseAPI}/userstatus/`);


### PR DESCRIPTION
Front-end fix for https://github.com/mozilla/network-pulse-api/pull/413 and the api side must land first.

Simply separates out the login/logout urls since every other pulse api url has a prefix of `/api/pulse` whereas these two routes do not.
