### PR TITLE
Update package.json: do not run build on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "bootstrap": "shx rm -rf dist && shx mkdir dist",
     "start": "npm run build && run-p server watch:**",
     "build": "run-s bootstrap build:**",
+    "heroku-postbuild": "echo Skip builds on Heroku",
     "build:client": "run-s build-client:**",
     "build-client:js": "webpack --config webpack.config.js --display-error-details --colors",
     "build-client:scss": "node-sass scss/main.scss dist/css/main.css",
@@ -108,5 +109,6 @@
     "node": "^8.9.0",
     "npm": "^6.0.0"
   },
-  "snyk": true
+  "snyk": true,
+  "heroku-run-build-script": true
 }


### PR DESCRIPTION
Heroku is changing is default: if a `build` step is present, it will be used, which we don't want.

```
       Detected both "build" and "heroku-postbuild" scripts

       Running heroku-postbuild

       

       > network-pulse@2.0.0 heroku-postbuild /tmp/build_6107274ab6befd90b34601a814546d24

       > echo Skip builds on Heroku
```