### PR TITLE
Remove "contact" link from footer

### DIFF
--- a/components/footer/footer.jsx
+++ b/components/footer/footer.jsx
@@ -22,11 +22,6 @@ const Footer = () => {
       iconType: `privacy`,
       link: `https://www.mozilla.org/privacy/websites/`,
       text: `Privacy`
-    },
-    {
-      iconType: `email`,
-      link: `https://mzl.la/pulse-contact`,
-      text: `Contact Us`
     }
   ];
 


### PR DESCRIPTION
The contact form is getting a bunch of people looking for Mozilla related help. I suspect they're coming from this footer. The link is still up in entries for edits.

Related issue:
Summary:

If you don't know who to ask for a review, try @alanmoo or @xmatthewx. If you do, please delete this line.
