### PR TITLE
Optimize creator autocomplete

### DIFF
--- a/js/service.js
+++ b/js/service.js
@@ -240,7 +240,7 @@ let Service = {
   },
   creators: {
     get: function(fragment) {
-      return getDataFromURL(`${pulseAPI}/profiles/`, {name: fragment});
+      return getDataFromURL(`${pulseAPI}/profiles/`, {name: fragment, basic: true});
     }
   },
   logout: function() {

--- a/pages/add/form/creators.js
+++ b/pages/add/form/creators.js
@@ -35,12 +35,12 @@ export default class Creators extends AutoCompleteInput {
       .get(fragment)
       .then(profiles => {
         let suggestions = profiles.map(creator => {
-          if(creator.profile_id) {
+          if(creator.is_active) {
             creator.name = PROFILE_PREFIX + creator.name;
           }
 
           return {
-            id: creator.profile_id,
+            id: creator.id,
             name: creator.name
           };
         });


### PR DESCRIPTION
Fixes two things I noticed:
1. Autocomplete from creators used `/profiles?name=` instead of `/profiles/?name=...&basic=true`. The first one gets a lot of unnecessary data which isn't used, so it's a performance drag on the db.
2. We attached the generic profile image in the autocomplete to every single creator (we used `profile_id` which is something every creator has) whether they were a creator with a profile or a creator without one. This fixes that. My guess is that it was because we didn't fully fix the code when we switched to v2 of the api.

To test:
1. When adding an entry, try to trigger autocomplete for a creator. Check the request to the api and make sure the returned response from the api is an array with each object only containing `id`, `name`, and `is_active`.
2. Choose an autocomplete which will fetch a mix of creators with profiles and creators without profiles (you can differentiate based on the `is_active` flag). Make sure that only the creators with profiles have the generic profile image attached to them in the autocomplete list.