### PR TITLE
remove unecessary Heroku flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,5 @@
     "node": "^8.9.0",
     "npm": "^6.0.0"
   },
-  "snyk": true,
-  "heroku-run-build-script": true
+  "snyk": true
 }


### PR DESCRIPTION
Remove `heroku-run-build-script` cf https://github.com/MozillaFoundation/mofo-devops-private/issues/205
ref MozillaFoundation/mofo-devops-private#208