### PR TITLE
Updating btn-link styles

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -42,15 +42,22 @@ h2 {
 }
 
 .btn-link {
+  background: transparent;
+  border: none;
+  font-family: inherit;
+  font-weight: normal;
+  cursor: pointer;
+  color: $dark-blue;
+
   &.inline-link {
-    font-family: inherit;
+    @include link-text-decoration(none,underline);
+
+    color: $dark-blue;
     font-size: inherit;
     line-height: inherit;
     vertical-align: inherit;
     padding: 0;
     border: 0;
-
-    @include link-text-decoration;
   }
 }
 


### PR DESCRIPTION
Related issue: #1066 

This will update all elements with `.btn-link .inline-link` classes to follow `a` link styles. This affects:

1. The dismiss "x" on mobile nav menu
2. Link in text on the bookmarks page
3. Profile sign in/out button