### PR TITLE
Update anchor default styles

### DIFF
--- a/scss/mixin.scss
+++ b/scss/mixin.scss
@@ -18,7 +18,7 @@
   }
 }
 
-@mixin link-text-decoration($normal-state: $link-decoration, $hover-state: $link-decoration) {
+@mixin link-text-decoration($normal-state: none, $hover-state: underline) {
   text-decoration: $normal-state;
 
   @include hover-focus-active {

--- a/scss/mixin.scss
+++ b/scss/mixin.scss
@@ -18,7 +18,7 @@
   }
 }
 
-@mixin link-text-decoration($normal-state: none, $hover-state: underline) {
+@mixin link-text-decoration($normal-state: none, $hover-state: $link-decoration) {
   text-decoration: $normal-state;
 
   @include hover-focus-active {

--- a/scss/overrides/_variables.scss
+++ b/scss/overrides/_variables.scss
@@ -21,7 +21,6 @@ $form-error-color: #d24735;
 $body-color: $black;
 $link-color: inherit;
 $link-hover-color: darken($mobile-blue, 15%);
-$link-decoration: underline;
 $font-weight-normal: normal;
 $btn-border-radius: 0;
 $btn-border-radius-sm: $btn-border-radius;

--- a/scss/overrides/_variables.scss
+++ b/scss/overrides/_variables.scss
@@ -21,6 +21,7 @@ $form-error-color: #d24735;
 $body-color: $black;
 $link-color: inherit;
 $link-hover-color: darken($mobile-blue, 15%);
+$link-decoration: underline;
 $font-weight-normal: normal;
 $btn-border-radius: 0;
 $btn-border-radius-sm: $btn-border-radius;


### PR DESCRIPTION
Closes  #1072 

_*Updated `@mixin link-text-decoration` to `text-decoration: none` default, but underline on hover_
