### PR TITLE
Update anchor default styles (override)

### DIFF
--- a/scss/mixin.scss
+++ b/scss/mixin.scss
@@ -18,7 +18,7 @@
   }
 }
 
-@mixin link-text-decoration($normal-state: none, $hover-state: $link-decoration) {
+@mixin link-text-decoration($normal-state: $link-decoration, $hover-state: $link-decoration) {
   text-decoration: $normal-state;
 
   @include hover-focus-active {


### PR DESCRIPTION
The issue with the anchor styling is coming from an older version of Bootstrap styles and needs to be overridden.