### PR TITLE
Found source of <a> underline & updated it

### DIFF
--- a/scss/overrides/_type.scss
+++ b/scss/overrides/_type.scss
@@ -12,3 +12,7 @@ h4,
 .h4-heading {
   @include scaleText(22px, 32px, 24px, 30px);
 }
+
+a {
+  @include link-text-decoration;
+}


### PR DESCRIPTION
The issue with the anchor styling is coming from `../node_modules/bootstrap/scss/reboot.scss` import on L12 of `main.scss`.  This pr adds an override for site-wide anchor tags. ( Ref: #1094, #1098)

Post 🚀 clean up ticket: #1100