### PR TITLE
Entry button Fix

### DIFF
--- a/components/project-card/project-card-detailed.jsx
+++ b/components/project-card/project-card-detailed.jsx
@@ -122,13 +122,17 @@ class DetailedProjectCard extends React.Component {
   }
 
   renderVisitButton() {
+    let classes = classNames("btn btn-primary mb-3 mb-md-0 mr-md-3 d-flex justify-content-center align-items-center", {
+    "single-btn": !this.props.getInvolvedUrl
+    });
+
     if (!this.props.contentUrl) return null;
 
     return (
       <a
         href={this.props.contentUrl}
         target="_blank"
-        className="btn btn-primary mb-3 mb-md-0 mr-md-3 d-flex justify-content-center align-items-center"
+        className={classes}
         onClick={() => this.handleVisitBtnClick()}
       >
         Visit

--- a/components/project-card/project-card-detailed.jsx
+++ b/components/project-card/project-card-detailed.jsx
@@ -122,11 +122,11 @@ class DetailedProjectCard extends React.Component {
   }
 
   renderVisitButton() {
-    let classes = classNames("btn btn-primary mb-3 mb-md-0 mr-md-3 d-flex justify-content-center align-items-center", {
-    "single-btn": !this.props.getInvolvedUrl
-    });
-
     if (!this.props.contentUrl) return null;
+
+    let classes = classNames("btn btn-primary mb-3 mb-md-0 mr-md-3 d-flex justify-content-center align-items-center", {
+      "single-btn": !this.props.getInvolvedUrl
+    });
 
     return (
       <a

--- a/components/project-card/project-card-detailed.scss
+++ b/components/project-card/project-card-detailed.scss
@@ -143,10 +143,8 @@
 
       @media (min-width: $bp-lg) {
         flex: 1;
-      }
 
-      &.single-btn {
-        @media (min-width: $bp-lg) {
+        &.single-btn {
           flex: 0.5;
         }
       }

--- a/components/project-card/project-card-detailed.scss
+++ b/components/project-card/project-card-detailed.scss
@@ -144,6 +144,12 @@
       @media (min-width: $bp-lg) {
         flex: 1;
       }
+
+      &.single-btn {
+        @media (min-width: $bp-lg) {
+          flex: 0.5;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Related issue: #1130
Summary: Visit button spans full width when Get Involved button isn't there (see [here](https://pulse.mofostaging.net/entry/492)). Fix involves keeping Visit button half width even when Get Involved Button not visible.

p.s. sorry mavis 😭 

_Note_: Commit should say 'bug' fix...not 'big' fix.