### PR TITLE
add side-margin for error message on 'Add' page

### DIFF
--- a/pages/add/add.jsx
+++ b/pages/add/add.jsx
@@ -254,7 +254,7 @@ class Add extends React.Component {
               clarity and style.
             </p>
             <button
-              className="btn btn-primary"
+              className="btn btn-primary mr-3"
               type="submit"
               onClick={evt => this.handleFormSubmit(evt)}
               disabled={this.state.submitting ? `disabled` : null}


### PR DESCRIPTION
Related issue: #1140 
Summary: Added side margin to the error message on 'Add page'

Please review @alanmoo @mmmavis 

Screenshots for change:

![image](https://user-images.githubusercontent.com/31389740/67974648-d39a8c80-fc38-11e9-9be9-44c6b7bb7605.png)
