### PR TITLE
make server error on 'add' and 'profile' page sit on their lines on small screen devices

### DIFF
--- a/pages/add/add.jsx
+++ b/pages/add/add.jsx
@@ -254,18 +254,22 @@ class Add extends React.Component {
               clarity and style.
             </p>
             <button
-              className="btn btn-primary d-block d-sm-inline-block mb-2 mb-sm-0 mr-sm-3"
+              className="btn btn-primary"
               type="submit"
               onClick={evt => this.handleFormSubmit(evt)}
               disabled={this.state.submitting ? `disabled` : null}
             >
               {this.state.submitting ? SUBMITTING_LABEL : PRE_SUBMIT_LABEL}
             </button>
-            {authErrorMessage}
-            {serverErrorMessage}
-            {this.state.showFormInvalidNotice && (
-              <span>Something isn't right. Check your info above.</span>
-            )}
+            <div className="d-sm-inline-block mt-2 mt-sm-0 ml-sm-3">
+              {authErrorMessage}
+              {serverErrorMessage}
+              {this.state.showFormInvalidNotice && (
+                <span className="error">
+                  Something isn't right. Check your info above.
+                </span>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/pages/add/add.jsx
+++ b/pages/add/add.jsx
@@ -254,7 +254,7 @@ class Add extends React.Component {
               clarity and style.
             </p>
             <button
-              className="btn btn-primary mr-3"
+              className="btn btn-primary d-block d-sm-inline-block mb-2 mb-sm-0 mr-sm-3"
               type="submit"
               onClick={evt => this.handleFormSubmit(evt)}
               disabled={this.state.submitting ? `disabled` : null}

--- a/pages/profile-edit/profile-edit.jsx
+++ b/pages/profile-edit/profile-edit.jsx
@@ -209,18 +209,22 @@ class ProfileEdit extends React.Component {
             </p>
             <div className="mt-4">
               <button
-                className="btn btn-primary d-block d-md-inline-block mb-2 mb-md-0 mr-md-3"
+                className="btn btn-primary"
                 type="submit"
                 onClick={event => this.handleFormSubmit(event)}
                 disabled={this.state.submitting ? `disabled` : null}
               >
                 {this.state.submitting ? SUBMITTING_LABEL : PRE_SUBMIT_LABEL}
               </button>
-              {authErrorMessage}
-              {serverErrorMessage}
-              {this.state.showFormInvalidNotice && (
-                <span>Something isn't right. Check your info above.</span>
-              )}
+              <div className="d-md-inline-block mt-2 mt-md-0 ml-md-3">
+                {authErrorMessage}
+                {serverErrorMessage}
+                {this.state.showFormInvalidNotice && (
+                  <span className="error">
+                    Something isn't right. Check your info above.
+                  </span>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/pages/profile-edit/profile-edit.jsx
+++ b/pages/profile-edit/profile-edit.jsx
@@ -209,7 +209,7 @@ class ProfileEdit extends React.Component {
             </p>
             <div className="mt-4">
               <button
-                className="btn btn-primary mr-3"
+                className="btn btn-primary d-block d-md-inline-block mb-2 mb-md-0 mr-md-3"
                 type="submit"
                 onClick={event => this.handleFormSubmit(event)}
                 disabled={this.state.submitting ? `disabled` : null}

--- a/scss/form.scss
+++ b/scss/form.scss
@@ -50,7 +50,7 @@ $field-hint-font-size: 0.875rem;
 }
 
 .submit-section {
-  button + span {
+  .error {
     color: $form-error-color;
   }
 }


### PR DESCRIPTION
Related issue: #1157 #1140 

Summary: make server error on 'add' and 'profile' page sit on their lines on small screen devices.

> **SCREENSHOTS:**

**"add" page:**

![image](https://user-images.githubusercontent.com/31389740/69027832-2f656380-09f6-11ea-8d15-6b29c8d93e87.png)


**"/myprofile" page:**

![image](https://user-images.githubusercontent.com/31389740/69027919-6b98c400-09f6-11ea-8b86-0fe11f75d7e6.png)

@mmmavis Please review
