### PR TITLE
Add back 'heroku-postbuild' npm task

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "bootstrap": "shx rm -rf dist && shx mkdir dist",
     "start": "npm run build:dev && run-p server watch:**",
     "build": "run-s bootstrap build:**",
+    "heroku-postbuild": "echo Skip builds on Heroku",
     "build:prod": "run-s bootstrap build-client:** build-js:prod:**",
     "build:dev": "run-s bootstrap build-client:** build-js:dev:**",
     "build-js:prod:server": "webpack --config webpack.server.prod.js --display-error-details --colors",


### PR DESCRIPTION
Related issue: PR https://github.com/mozilla/network-pulse/pull/1165

I [accidentally removed this task](https://github.com/mozilla/network-pulse/pull/1165/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L10) in my previous PR. Adding it back now.