### PR TITLE
Fix profile search bug

### DIFF
--- a/components/profile-card/profile-card.jsx
+++ b/components/profile-card/profile-card.jsx
@@ -12,10 +12,7 @@ export default props => {
     }
 
     return (
-      <Link
-        to={`/profile/${props.id}`}
-        onClick={event => props.creatorClickHandler(event, name)}
-      >
+      <Link to={`/profile/${props.id}`}>
         <div className="thumbnail mx-auto" style={style} />
       </Link>
     );
@@ -41,12 +38,7 @@ export default props => {
         </div>
         <div className="col-sm-9">
           <h2 className="name text-center text-sm-left">
-            <Link
-              to={`/profile/${props.id}`}
-              onClick={event => props.creatorClickHandler(event, name)}
-            >
-              {props.name}
-            </Link>
+            <Link to={`/profile/${props.id}`}>{props.name}</Link>
           </h2>
           {renderProfileBlurb(props.user_bio)}
         </div>


### PR DESCRIPTION
Closes #1204 

Removed extra event handler that was probably copied and pasted by mistake. (I cross-checked with our [GA event spreadsheet](https://docs.google.com/spreadsheets/d/1x-CP_HYaAs3oRv2cjbSFu8w5Z938E4cyHQ3hvh17c6c/edit#gid=1060389854) and didn't see any "profile" related event lists)

https://network-pulse-staging-pr-1205.herokuapp.com/people?keyword=mavis