### PR TITLE
Pass github token in headers and not as a query param

### DIFF
--- a/js/review-app-slack-webhook.js
+++ b/js/review-app-slack-webhook.js
@@ -18,7 +18,13 @@ const slack_webhook = process.env.SLACK_WEBHOOK;
 if (pr_number) {
   request(
     `https://api.github.com/repos/${org}/${repo}/pulls/${pr_number}&access_token=${github_token}`,
-    { headers: { "User-Agent": "request" } },
+    {
+      headers: [
+          {
+            "User-Agent": "request",
+            "Authorization": `token ${github_token}`
+          }
+      ],
     function(error, response, body) {
       if (!error && response.statusCode === 200) {
         const pr_title = JSON.parse(body)["title"];

--- a/js/review-app-slack-webhook.js
+++ b/js/review-app-slack-webhook.js
@@ -19,12 +19,11 @@ if (pr_number) {
   request(
     `https://api.github.com/repos/${org}/${repo}/pulls/${pr_number}&access_token=${github_token}`,
     {
-      headers: [
-          {
-            "User-Agent": "request",
-            "Authorization": `token ${github_token}`
-          }
-      ],
+      headers: {
+        "User-Agent": "request",
+        Authorization: `token ${github_token}`
+      }
+    },
     function(error, response, body) {
       if (!error && response.statusCode === 200) {
         const pr_title = JSON.parse(body)["title"];

--- a/js/review-app-slack-webhook.js
+++ b/js/review-app-slack-webhook.js
@@ -17,7 +17,7 @@ const slack_webhook = process.env.SLACK_WEBHOOK;
 // For review app manually created, we have to use the branch name instead.
 if (pr_number) {
   request(
-    `https://api.github.com/repos/${org}/${repo}/pulls/${pr_number}&access_token=${github_token}`,
+    `https://api.github.com/repos/${org}/${repo}/pulls/${pr_number}`,
     {
       headers: {
         "User-Agent": "request",


### PR DESCRIPTION
Using token in query params are not deprecated.

Related PRs/issues mozillafoundation/mofo-devops-private#297