### PR TITLE
heroku-postbuild, not heroku-postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bootstrap": "shx rm -rf dist && shx mkdir dist",
     "start": "npm run build:dev && run-p server watch:**",
     "build": "run-s bootstrap build:**",
-    "heroku-postbuild": "echo Skip builds on Heroku",
+    "heroku-postbuild": "npm run build:prod",
     "build:prod": "run-s bootstrap build-client:** build-js:prod:**",
     "build:dev": "run-s bootstrap build-client:** build-js:dev:**",
     "build-js:prod:server": "webpack --config webpack.server.prod.js --display-error-details --colors",
@@ -34,8 +34,7 @@
     "test": "run-s test:**",
     "test:eslint": "eslint --config ./.eslintrc.json  \"*.js\" \"*.jsx\" \"js/**/*.js\" \"components/**/*.jsx\" \"pages/**/*.jsx\" \"pages/**/*.js\" webpack.**.js",
     "test:scss:styleguide:color": "stylelint \"components/**/*.scss\" \"pages/**/*.scss\" \"scss/**/*.scss\" \"!scss/foundation-styles/_variables.scss\" \"!scss/**/variables.scss\" \"!scss/overrides/_variables.scss\" --syntax scss --config .stylelintrc-colors.js",
-    "test:scss": "stylelint --config .stylelintrc \"components/**/*.scss\" \"pages/**/*.scss\" \"scss/**/*.scss\" --syntax scss",
-    "heroku-postinstall": "npm run build:prod"
+    "test:scss": "stylelint --config .stylelintrc \"components/**/*.scss\" \"pages/**/*.scss\" \"scss/**/*.scss\" --syntax scss"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Related issue: #1264 
Summary: We actually want to hook into `heroku-postbuild`, I missed that detail in my review of #1264
