### PR TITLE
Fix regression bugs due to recent 'react-tag-autocomplete' v6 uplift

### DIFF
--- a/pages/add/form/auto-complete-input.js
+++ b/pages/add/form/auto-complete-input.js
@@ -159,12 +159,11 @@ export default class AutoCompleteInput extends Component {
           tags={this.state.data}
           suggestions={this.getFilteredSuggestions()}
           allowNew={true}
-          autofocus={false}
           delimiters={DELIMITERS}
-          handleDelete={(...args) => this.handleDelete(...args)}
-          handleAddition={(...args) => this.handleAddition(...args)}
-          handleInputChange={(...args) => this.handleInputChange(...args)}
-          placeholder={placeholder}
+          onDelete={(...args) => this.handleDelete(...args)}
+          onAddition={(...args) => this.handleAddition(...args)}
+          onInput={(...args) => this.handleInputChange(...args)}
+          placeholderText={placeholder}
           classNames={{
             root: `react-tags form-control d-flex flex-column flex-sm-row`,
             selectedTag: `selected-tag btn btn-sm mr-sm-2 my-1`,

--- a/pages/add/form/detail-info-fields.js
+++ b/pages/add/form/detail-info-fields.js
@@ -26,7 +26,7 @@ export default {
   },
   related_creators: {
     type: Creators,
-    label: `Name any creators, contributors, partners. Comma separated.`,
+    label: `Name any creators, contributors, partners. Tab separated.`,
     fieldClassname: `form-control`,
   },
   interest: {
@@ -43,7 +43,7 @@ export default {
   },
   tags: {
     type: Tags,
-    label: `Tags: Comma separated. Spaces are ok. Issues are added automatically.`,
+    label: `Tags: Tab separated. Spaces are ok. Issues are added automatically.`,
     fieldClassname: `form-control`,
   },
   thumbnail: {

--- a/pages/add/form/detail-info-fields.js
+++ b/pages/add/form/detail-info-fields.js
@@ -26,7 +26,7 @@ export default {
   },
   related_creators: {
     type: Creators,
-    label: `Name any creators, contributors, partners. Tab separated.`,
+    label: `Name any creators, contributors, partners. Comma-separated.`,
     fieldClassname: `form-control`,
   },
   interest: {
@@ -43,7 +43,7 @@ export default {
   },
   tags: {
     type: Tags,
-    label: `Tags: Tab separated. Spaces are ok. Issues are added automatically.`,
+    label: `Tags: Comma-separated. Spaces in tag names are ok. Issues are added automatically.`,
     fieldClassname: `form-control`,
   },
   thumbnail: {

--- a/pages/add/form/tag-delimiters.js
+++ b/pages/add/form/tag-delimiters.js
@@ -1,10 +1,5 @@
-// keycodes for tab,enter,comma, used with
-// the react-tags-autocomplete component
-// The delimiters option is now an array of KeyboardEvent.key values and
-// not KeyboardEvent.keyCode codes,
-// e.g. [13, 9] should now be written as ['Enter', 'Tab']. See https://keycode.info/ for more information.
-
-// It seems like react-tags-autocomplete no longer accepts Comma as delimiter
-// GitHub ticket filed: https://github.com/i-like-robots/react-tags/issues/213
-const DELIMITERS = [`Tab`, `Enter`];
+// keycodes for tab,enter,comma, used with the react-tags-autocomplete component
+// Delimiters map to `KeyboardEvent.key` values,
+// see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Value
+const DELIMITERS = [`Tab`, `Enter`, `,`];
 export { DELIMITERS };

--- a/pages/add/form/tag-delimiters.js
+++ b/pages/add/form/tag-delimiters.js
@@ -1,4 +1,10 @@
 // keycodes for tab,enter,comma, used with
 // the react-tags-autocomplete component
-const DELIMITERS = [9, 13, 188];
+// The delimiters option is now an array of KeyboardEvent.key values and
+// not KeyboardEvent.keyCode codes,
+// e.g. [13, 9] should now be written as ['Enter', 'Tab']. See https://keycode.info/ for more information.
+
+// It seems like react-tags-autocomplete no longer accepts Comma as delimiter
+// GitHub ticket filed: https://github.com/i-like-robots/react-tags/issues/213
+const DELIMITERS = [`Tab`, `Enter`];
 export { DELIMITERS };

--- a/scss/form.scss
+++ b/scss/form.scss
@@ -79,15 +79,12 @@ span.char-limit {
   border-radius: 0;
   padding: 0.75rem;
   border-color: $gray-20;
+  height: auto;
 
   &:focus,
   &:active {
     border-color: $light-blue;
     box-shadow: none;
-  }
-
-  @media (min-width: $bp-md) {
-    padding: 1.0625rem 0.75rem;
   }
 }
 


### PR DESCRIPTION
Fixed #1360 

I should have been more careful with that Dependabot PR & visited the official `'react-tag-autocomplete` repo for more detailed docs before upgrading that library to v6. 

Note that autocomplete doesn't work for the "creator" field due to an API bug. I've filed a ticket on the API repo.