### PR TITLE
Fix footer checkout alignment (#1438)

### DIFF
--- a/components/newsletter-sign-up/newsletter-sign-up.jsx
+++ b/components/newsletter-sign-up/newsletter-sign-up.jsx
@@ -208,7 +208,7 @@ class NewsletterSignUp extends React.Component {
         <label className="form-check-label">
           <input
             type="checkbox"
-            className="form-check-input"
+            className="mt-1 form-check-input"
             id="PrivacyCheckbox"
             ref={(el) => (this.privacy = el)}
           />


### PR DESCRIPTION
Related issue: #1438
Summary:
Added a mt-1 to push the checkbox down, i don't know if that's ideal but it fixed it for me
I don't know who ask for review, I'll follow the pull guideline and tag @pomax 
