### PR TITLE
Add noindex, nofollow, noarchive for staging server

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ The review app slack bot will post a message in the `mofo-ra-pulse` with links a
 
 #### Environment variables:
 
-- `GITHUB_TOKEN`: GITHUB API authentication,
-- `SLACK_WEBHOOK_RA`: Webhook to `mofo-ra-pulse`
+- `GITHUB_TOKEN`: GITHUB API authentication.
+- `SLACK_WEBHOOK_RA`: Webhook to `mofo-ra-pulse`.
+- `STAGING_SERVER`: Boolean, set this to `True` on the staging server.
 
 Non-secret envs can be added to the `app.json` file. Secrets must be set on Heroku in the `Review Apps` (pipelines' `settings` tab).

--- a/server.js
+++ b/server.js
@@ -46,7 +46,7 @@ app.use(
 );
 
 // No-index and No-follow in "not production"
-if (STAGING_SERVER) {
+if (env.STAGING_SERVER) {
   app.use((req, res, next) => {
     res.setHeader('X-Robots-Tag', 'noindex, noarchive, nofollow');
     next();

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ app.use(
 // No-index and No-follow in "not production"
 if (env.STAGING_SERVER) {
   app.use((req, res, next) => {
-    res.setHeader('X-Robots-Tag', 'noindex, noarchive, nofollow');
+    res.setHeader("X-Robots-Tag", "noindex, noarchive, nofollow");
     next();
   });
 }
@@ -137,7 +137,11 @@ function renderPage(appHtml, reactHelmet, canonicalUrl) {
         <title>"${meta.title}"</title>
         <meta name="description" content="${meta.description}">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        ${env.STAGING_SERVER && <meta name="googlebot" content="noindex, nofollow, noarchive" />}
+        ${
+          env.STAGING_SERVER && (
+            <meta name="googlebot" content="noindex, nofollow, noarchive" />
+          )
+        }
         <meta charset="utf-8">
         ${twitterCard}
         ${ogTags}

--- a/server.js
+++ b/server.js
@@ -139,13 +139,12 @@ function renderPage(appHtml, reactHelmet, canonicalUrl) {
       <head>
         <title>"${meta.title}"</title>
         <meta name="description" content="${meta.description}">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        ${
-          ON_STAGING_SERVER && (
-            <meta name="googlebot" content="noindex, nofollow, noarchive" />
-          )
-        }
-        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">${
+          ON_STAGING_SERVER &&
+          `
+        <meta name="googlebot" content="noindex, nofollow, noarchive" />
+        `
+        }<meta charset="utf-8">
         ${twitterCard}
         ${ogTags}
         <script type="text/javascript" async src="https://platform.twitter.com/widgets.js"></script>

--- a/server.js
+++ b/server.js
@@ -25,6 +25,9 @@ const APP_HOST = env.APP_HOST;
 // what environment are we running in
 const NODE_ENV = env.NODE_ENV;
 
+// are we running on staging?
+const ON_STAGING_SERVER = env.STAGING_SERVER === `True`;
+
 // maxAge for HSTS header must be at least 6 months
 // (see https://wiki.mozilla.org/Security/Guidelines/Web_Security#HTTP_Strict_Transport_Security)
 const hstsMiddleware = helmet.hsts({
@@ -46,7 +49,7 @@ app.use(
 );
 
 // No-index and No-follow in "not production"
-if (env.STAGING_SERVER) {
+if (ON_STAGING_SERVER) {
   app.use((req, res, next) => {
     res.setHeader("X-Robots-Tag", "noindex, noarchive, nofollow");
     next();
@@ -138,7 +141,7 @@ function renderPage(appHtml, reactHelmet, canonicalUrl) {
         <meta name="description" content="${meta.description}">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         ${
-          env.STAGING_SERVER && (
+          ON_STAGING_SERVER && (
             <meta name="googlebot" content="noindex, nofollow, noarchive" />
           )
         }

--- a/server.js
+++ b/server.js
@@ -46,7 +46,7 @@ app.use(
 );
 
 // No-index and No-follow in "not production"
-if (NODE_ENV !== 'production') {
+if (STAGING_SERVER) {
   app.use((req, res, next) => {
     res.setHeader('X-Robots-Tag', 'noindex, noarchive, nofollow');
     next();
@@ -72,7 +72,7 @@ app.use(
 );
 
 // production specific configuration and middleware
-if (env.STAGING_SERVER) {
+if (NODE_ENV === `production`) {
   // trust x-forwarded-proto headers in production
   app.enable(`trust proxy`);
 

--- a/server.js
+++ b/server.js
@@ -45,6 +45,14 @@ app.use(
   })
 );
 
+// No-index and No-follow in "not production"
+if (NODE_ENV !== 'production') {
+  app.use((req, res, next) => {
+    res.setHeader('X-Robots-Tag', 'noindex, noarchive, nofollow');
+    next();
+  });
+}
+
 app.use((req, res, next) => {
   if (req.secure) {
     hstsMiddleware(req, res, next);
@@ -64,7 +72,7 @@ app.use(
 );
 
 // production specific configuration and middleware
-if (NODE_ENV === `production`) {
+if (env.STAGING_SERVER) {
   // trust x-forwarded-proto headers in production
   app.enable(`trust proxy`);
 
@@ -129,6 +137,7 @@ function renderPage(appHtml, reactHelmet, canonicalUrl) {
         <title>"${meta.title}"</title>
         <meta name="description" content="${meta.description}">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        ${env.STAGING_SERVER && <meta name="googlebot" content="noindex, nofollow, noarchive" />}
         <meta charset="utf-8">
         ${twitterCard}
         ${ogTags}


### PR DESCRIPTION
Closes #1529

This adds noindex/nofollow/noarchive to our express responses as both an HTTP header and a google-specific meta tag (because of course Google is special, why wouldn't it be).

This relies on an env var `STAGING_SERVER`, which I've already set to `True` on the heroku staging server.