### PR TITLE
 updated to use data layer + only fire when checkbox is checked

### DIFF
--- a/components/newsletter-sign-up/newsletter-sign-up.jsx
+++ b/components/newsletter-sign-up/newsletter-sign-up.jsx
@@ -82,13 +82,21 @@ class NewsletterSignUp extends React.Component {
 
     if (email && this.validatesAsEmail(email) && consent) {
       this.submitDataToApi();
+      Analytics.ReactGA.event({
+        category: `signup`,
+        action: `form submit tap`,
+        label: `Signup submitted`,
+      });
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: 'form_submission',
+        form_type: 'newsletter_signup', // type of form. should be static in this case
+        form_location: 'footer', // update with location of form in page -- either 'header' or 'footer', depending on which form the user used to sign up for the newsletter
+        country: 'argentina', // update according to the country the user selected from the dropdown, if the form has a country dropdown
+        language: 'english' // update according to the language that the user selected from the dropdown, if the form has a language dropdown
+        }
+      );
     }
-
-    Analytics.ReactGA.event({
-      category: `signup`,
-      action: `form submit tap`,
-      label: `Signup submitted`,
-    });
   }
 
   /**

--- a/components/newsletter-sign-up/newsletter-sign-up.jsx
+++ b/components/newsletter-sign-up/newsletter-sign-up.jsx
@@ -89,13 +89,10 @@ class NewsletterSignUp extends React.Component {
       });
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
-        event: 'form_submission',
-        form_type: 'newsletter_signup', // type of form. should be static in this case
-        form_location: 'footer', // update with location of form in page -- either 'header' or 'footer', depending on which form the user used to sign up for the newsletter
-        country: 'argentina', // update according to the country the user selected from the dropdown, if the form has a country dropdown
-        language: 'english' // update according to the language that the user selected from the dropdown, if the form has a language dropdown
-        }
-      );
+        event: "form_submission",
+        form_type: "newsletter_signup",
+        form_location: "footer",
+      });
     }
   }
 


### PR DESCRIPTION
Related issue:#1656


This PR adds a new data layer event to the pulse newsletter sign up form at the footer of the app, as well as moves the code within an if statement, to make sure that the event doesnt fire unless the user selects the privacy consent checkbox.


**Note:**

Per instructions in #1656, I have removed the language and country parameters, since the sign up form in pulse does **not** use these.
```
dataLayer code:
// Mozilla Foundation + Torchbox - 2022
// dataLayer push for newsletter signup form submission

window.dataLayer = window.dataLayer || [];
window.dataLayer.push({
  event: 'form_submission',
  form_type: 'newsletter_signup', // type of form. should be static in this case
  form_location: 'header', // update with location of form in page -- either 'header' or 'footer', depending on which form the user used to sign up for the newsletter
  country: 'argentina', // update according to the country the user selected from the dropdown, if the form has a country dropdown
  language: 'english' // update according to the language that the user selected from the dropdown, if the form has a language dropdown
  }
);

```

**Screenshot of event firing when its supposed to:**
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/18314510/184208137-c89c4b34-aa43-4e07-a853-e55c90104056.png">



